### PR TITLE
UCT/ROCM: fix memory type detection

### DIFF
--- a/examples/ucp_hello_world.c
+++ b/examples/ucp_hello_world.c
@@ -350,17 +350,12 @@ err:
     return ret;
 }
 
-static void flush_callback(void *request, ucs_status_t status, void *user_data)
-{
-}
-
 static ucs_status_t flush_ep(ucp_worker_h worker, ucp_ep_h ep)
 {
     ucp_request_param_t param;
     void *request;
 
-    param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK;
-    param.cb.send      = flush_callback;
+    param.op_attr_mask = 0;
     request            = ucp_ep_flush_nbx(ep, &param);
     if (request == NULL) {
         return UCS_OK;

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -612,42 +612,6 @@ enum ucp_cb_param_flags {
 
 /**
  * @ingroup UCP_COMM
- * @brief Atomic operation requested for ucp_atomic_post
- *
- * This enumeration defines which atomic memory operation should be
- * performed by the ucp_atomic_post family of functions. All of these are
- * non-fetching atomics and will not result in a request handle.
- */
-typedef enum {
-    UCP_ATOMIC_POST_OP_ADD, /**< Atomic add */
-    UCP_ATOMIC_POST_OP_AND, /**< Atomic and */
-    UCP_ATOMIC_POST_OP_OR,  /**< Atomic or  */
-    UCP_ATOMIC_POST_OP_XOR, /**< Atomic xor */
-    UCP_ATOMIC_POST_OP_LAST
-} ucp_atomic_post_op_t;
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Atomic operation requested for ucp_atomic_fetch
- *
- * This enumeration defines which atomic memory operation should be performed
- * by the ucp_atomic_fetch family of functions. All of these functions
- * will fetch data from the remote node.
- */
-typedef enum {
-    UCP_ATOMIC_FETCH_OP_FADD,  /**< Atomic Fetch and add    */
-    UCP_ATOMIC_FETCH_OP_SWAP,  /**< Atomic swap             */
-    UCP_ATOMIC_FETCH_OP_CSWAP, /**< Atomic conditional swap */
-    UCP_ATOMIC_FETCH_OP_FAND,  /**< Atomic Fetch and and    */
-    UCP_ATOMIC_FETCH_OP_FOR,   /**< Atomic Fetch and or     */
-    UCP_ATOMIC_FETCH_OP_FXOR,  /**< Atomic Fetch and xor    */
-    UCP_ATOMIC_FETCH_OP_LAST
-} ucp_atomic_fetch_op_t;
-
-
-/**
- * @ingroup UCP_COMM
  * @brief Atomic operation requested for ucp_atomic_op_nbx
  *
  * This enumeration defines which atomic memory operation should be
@@ -2126,27 +2090,6 @@ void ucp_worker_print_info(ucp_worker_h worker, FILE *stream);
 
 /**
  * @ingroup UCP_WORKER
- * @brief Get the address of the worker object.
- *
- * This routine returns the address of the worker object.  This address can be
- * passed to remote instances of the UCP library in order to connect to this
- * worker. The memory for the address handle is allocated by this function, and
- * must be released by using @ref ucp_worker_release_address
- * "ucp_worker_release_address()" routine.
- *
- * @param [in]  worker            Worker object whose address to return.
- * @param [out] address_p         A pointer to the worker address.
- * @param [out] address_length_p  The size in bytes of the address.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_worker_get_address(ucp_worker_h worker,
-                                    ucp_address_t **address_p,
-                                    size_t *address_length_p);
-
-
-/**
- * @ingroup UCP_WORKER
  * @brief Release an address of the worker object.
  *
  * This routine release an @ref ucp_address_t "address handle" associated within
@@ -2538,35 +2481,6 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
  *
  * @brief Non-blocking @ref ucp_ep_h "endpoint" closure.
  *
- * This routine releases the @ref ucp_ep_h "endpoint". The endpoint closure
- * process depends on the selected @a mode.
- *
- * @param [in]  ep      Handle to the endpoint to close.
- * @param [in]  mode    One from @ref ucp_ep_close_mode value.
- *
- * @return UCS_OK           - The endpoint is closed successfully.
- * @return UCS_PTR_IS_ERR(_ptr) - The closure failed and an error code indicates
- *                                the transport level status. However, resources
- *                                are released and the @a endpoint can no longer
- *                                be used.
- * @return otherwise        - The closure process is started, and can be
- *                            completed at any point in time. A request handle
- *                            is returned to the application in order to track
- *                            progress of the endpoint closure. The application
- *                            is responsible for releasing the handle using the
- *                            @ref ucp_request_free routine.
- *
- * @note @ref ucp_ep_close_nb replaces deprecated @ref ucp_disconnect_nb and
- *       @ref ucp_ep_destroy
- */
-ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode);
-
-
-/**
- * @ingroup UCP_ENDPOINT
- *
- * @brief Non-blocking @ref ucp_ep_h "endpoint" closure.
- *
  * @param [in]  ep      Handle to the endpoint to close.
  * @param [in]  param   Operation parameters, see @ref ucp_request_param_t.
  *                      This operation supports specific flags, which can be
@@ -2633,32 +2547,26 @@ void ucp_ep_print_info(ucp_ep_h ep, FILE *stream);
  * @ref ucp_ep_h "endpoint" when this call returns.
  *
  * @param [in] ep        UCP endpoint.
- * @param [in] flags     Flags for flush operation. Reserved for future use.
- * @param [in] cb        Callback which will be called when the flush operation
- *                       completes.
+ * @param [in] param     Operation parameters, see @ref ucp_request_param_t.
  *
- * @return NULL             - The flush operation was completed immediately.
+ * @return NULL                 - The flush operation was completed immediately.
  * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
- * @return otherwise        - Flush operation was scheduled and can be completed
- *                          in any point in time. The request handle is returned
- *                          to the application in order to track progress. The
- *                          application is responsible for releasing the handle
- *                          using @ref ucp_request_free "ucp_request_free()"
- *                          routine.
+ * @return otherwise            - Flush operation was scheduled and can be
+ *                                completed in any point in time. The request
+ *                                handle is returned to the application in
+ *                                order to track progress.
  *
  *
  * The following example demonstrates how blocking flush can be implemented
  * using non-blocking flush:
  * @code {.c}
- * void empty_function(void *request, ucs_status_t status)
- * {
- * }
- *
  * ucs_status_t blocking_ep_flush(ucp_ep_h ep, ucp_worker_h worker)
  * {
+ *     ucp_request_param_t param;
  *     void *request;
  *
- *     request = ucp_ep_flush_nb(ep, 0, empty_function);
+ *     param.op_attr_mask = 0;
+ *     request            = ucp_ep_flush_nbx(ep, &param);
  *     if (request == NULL) {
  *         return UCS_OK;
  *     } else if (UCS_PTR_IS_ERR(request)) {
@@ -2673,31 +2581,7 @@ void ucp_ep_print_info(ucp_ep_h ep, FILE *stream);
  *         return status;
  *     }
  * }
- * @endcode */
-ucs_status_ptr_t ucp_ep_flush_nb(ucp_ep_h ep, unsigned flags,
-                                 ucp_send_callback_t cb);
-
-
-/**
- * @ingroup UCP_ENDPOINT
- *
- * @brief Non-blocking flush of outstanding AMO and RMA operations on the
- * @ref ucp_ep_h "endpoint".
- *
- * This routine flushes all outstanding AMO and RMA communications on the
- * @ref ucp_ep_h "endpoint". All the AMO and RMA operations issued on the
- * @a ep prior to this call are completed both at the origin and at the target
- * @ref ucp_ep_h "endpoint" when this call returns.
- *
- * @param [in] ep        UCP endpoint.
- * @param [in] param     Operation parameters, see @ref ucp_request_param_t.
- *
- * @return NULL                 - The flush operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
- * @return otherwise            - Flush operation was scheduled and can be
- *                                completed in any point in time. The request
- *                                handle is returned to the application in
- *                                order to track progress.
+ * @endcode
  */
 ucs_status_ptr_t ucp_ep_flush_nbx(ucp_ep_h ep, const ucp_request_param_t *param);
 
@@ -3062,36 +2946,6 @@ void ucp_rkey_destroy(ucp_rkey_h rkey);
  *
  * This routine installs a user defined callback to handle incoming Active
  * Messages with a specific id. This callback is called whenever an Active
- * Message that was sent from the remote peer by @ref ucp_am_send_nb is
- * received on this worker.
- *
- * @param [in]  worker      UCP worker on which to set the Active Message
- *                          handler.
- * @param [in]  id          Active Message id.
- * @param [in]  cb          Active Message callback. NULL to clear.
- * @param [in]  arg         Active Message argument, which will be passed
- *                          in to every invocation of the callback as the
- *                          arg argument.
- * @param [in]  flags       Dictates how an Active Message is handled on the
- *                          remote endpoint. Currently only
- *                          UCP_AM_FLAG_WHOLE_MSG is supported, which
- *                          indicates the callback will not be invoked
- *                          until all data has arrived.
- *
- * @return error code if the worker does not support Active Messages or
- *         requested callback flags.
- */
-ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id,
-                                       ucp_am_callback_t cb, void *arg,
-                                       uint32_t flags);
-
-
-/**
- * @ingroup UCP_WORKER
- * @brief Add user defined callback for Active Message.
- *
- * This routine installs a user defined callback to handle incoming Active
- * Messages with a specific id. This callback is called whenever an Active
  * Message that was sent from the remote peer by @ref ucp_am_send_nbx is
  * received on this worker.
  *
@@ -3108,35 +2962,6 @@ ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id,
  */
 ucs_status_t ucp_worker_set_am_recv_handler(ucp_worker_h worker,
                                             const ucp_am_handler_param_t *param);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Send Active Message.
- *
- * This routine sends an Active Message to an ep. It does not support
- * CUDA memory.
- *
- * @param [in]  ep          UCP endpoint where the Active Message will be run.
- * @param [in]  id          Active Message id. Specifies which registered
- *                          callback to run.
- * @param [in]  buffer      Pointer to the data to be sent to the target node
- *                          of the Active Message.
- * @param [in]  count       Number of elements to send.
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  cb          Callback that is invoked upon completion of the
- *                          data transfer if it is not completed immediately.
- * @param [in]  flags       Operation flags as defined by @ref ucp_send_am_flags.
- *
- * @return NULL             Active Message was sent immediately.
- * @return UCS_PTR_IS_ERR(_ptr) Error sending Active Message.
- * @return otherwise        Pointer to request, and Active Message is known
- *                          to be completed after cb is run.
- */
-ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
-                                const void *buffer, size_t count,
-                                ucp_datatype_t datatype,
-                                ucp_send_callback_t cb, unsigned flags);
 
 
 /**
@@ -3263,49 +3088,6 @@ void ucp_am_data_release(ucp_worker_h worker, void *data);
  * @brief Non-blocking stream send operation.
  *
  * This routine sends data that is described by the local address @a buffer,
- * size @a count, and @a datatype object to the destination endpoint @a ep.
- * The routine is non-blocking and therefore returns immediately, however
- * the actual send operation may be delayed. The send operation is considered
- * completed when it is safe to reuse the source @e buffer. If the send
- * operation is completed immediately the routine returns UCS_OK and the
- * callback function @a cb is @b not invoked. If the operation is
- * @b not completed immediately and no error reported, then the UCP library will
- * schedule invocation of the callback @a cb upon completion of the send
- * operation. In other words, the completion of the operation will be signaled
- * either by the return code or by the callback.
- *
- * @note The user should not modify any part of the @a buffer after this
- *       operation is called, until the operation completes.
- *
- * @param [in]  ep          Destination endpoint handle.
- * @param [in]  buffer      Pointer to the message buffer (payload).
- * @param [in]  count       Number of elements to send.
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          send operation is completed. It is important to note
- *                          that the callback is only invoked in the event that
- *                          the operation cannot be completed in place.
- * @param [in]  flags       Reserved for future use.
- *
- * @return NULL             - The send operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
- * @return otherwise        - Operation was scheduled for send and can be
- *                          completed in any point in time. The request handle
- *                          is returned to the application in order to track
- *                          progress of the message. The application is
- *                          responsible for releasing the handle using
- *                          @ref ucp_request_free routine.
- */
-ucs_status_ptr_t ucp_stream_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
-                                    ucp_datatype_t datatype, ucp_send_callback_t cb,
-                                    unsigned flags);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking stream send operation.
- *
- * This routine sends data that is described by the local address @a buffer,
  * size @a count object to the destination endpoint @a ep. The routine is
  * non-blocking and therefore returns immediately, however the actual send
  * operation may be delayed. The send operation is considered completed when
@@ -3329,167 +3111,6 @@ ucs_status_ptr_t ucp_stream_send_nb(ucp_ep_h ep, const void *buffer, size_t coun
  */
 ucs_status_ptr_t ucp_stream_send_nbx(ucp_ep_h ep, const void *buffer, size_t count,
                                      const ucp_request_param_t *param);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking tagged-send operations
- *
- * This routine sends a messages that is described by the local address @a
- * buffer, size @a count, and @a datatype object to the destination endpoint
- * @a ep. Each message is associated with a @a tag value that is used for
- * message matching on the @ref ucp_tag_recv_nb "receiver". The routine is
- * non-blocking and therefore returns immediately, however the actual send
- * operation may be delayed. The send operation is considered completed when
- * it is safe to reuse the source @e buffer. If the send operation is
- * completed immediately the routine return UCS_OK and the call-back function
- * @a cb is @b not invoked. If the operation is @b not completed immediately
- * and no error reported then the UCP library will schedule to invoke the
- * call-back @a cb whenever the send operation will be completed. In other
- * words, the completion of a message can be signaled by the return code or
- * the call-back.
- *
- * @note The user should not modify any part of the @a buffer after this
- *       operation is called, until the operation completes.
- *
- * @param [in]  ep          Destination endpoint handle.
- * @param [in]  buffer      Pointer to the message buffer (payload).
- * @param [in]  count       Number of elements to send
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          send operation is completed. It is important to note
- *                          that the call-back is only invoked in a case when
- *                          the operation cannot be completed in place.
- *
- * @return NULL            - The send operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
- * @return otherwise        - Operation was scheduled for send and can be
- *                          completed in any point in time. The request handle
- *                          is returned to the application in order to track
- *                          progress of the message. The application is
- *                          responsible for releasing the handle using
- *                          @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_tag_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
-                                 ucp_datatype_t datatype, ucp_tag_t tag,
-                                 ucp_send_callback_t cb);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking tagged-send operations with user provided request
- *
- * This routine provides a convenient and efficient way to implement a
- * blocking send pattern. It also completes requests faster than
- * @ref ucp_tag_send_nb() because:
- * @li it always uses eager protocol to send data up to the
- *     rendezvous threshold.
- * @li its rendezvous threshold is higher than the one used by
- *     the @ref ucp_tag_send_nb(). The threshold is controlled by
- *     the @b UCX_SEND_NBR_RNDV_THRESH environment variable.
- * @li its request handling is simpler. There is no callback and no need
- *     to allocate and free requests. In fact request can be allocated by
- *     caller on the stack.
- *
- * This routine sends a messages that is described by the local address @a
- * buffer, size @a count, and @a datatype object to the destination endpoint
- * @a ep. Each message is associated with a @a tag value that is used for
- * message matching on the @ref ucp_tag_recv_nbr "receiver".
- *
- * The routine is non-blocking and therefore returns immediately, however
- * the actual send operation may be delayed. The send operation is considered
- * completed when it is safe to reuse the source @e buffer. If the send
- * operation is completed immediately the routine returns UCS_OK.
- *
- * If the operation is @b not completed immediately and no error reported
- * then the UCP library will fill a user provided @a req and
- * return UCS_INPROGRESS status. In order to monitor completion of the
- * operation @ref ucp_request_check_status() should be used.
- *
- * Following pseudo code implements a blocking send function:
- * @code
- * MPI_send(...)
- * {
- *     char *request;
- *     ucs_status_t status;
- *
- *     // allocate request on the stack
- *     // ucp_context_query() was used to get ucp_request_size
- *     request = alloca(ucp_request_size);
- *
- *     // note: make sure that there is enough memory before the
- *     // request handle
- *     status = ucp_tag_send_nbr(ep, ..., request + ucp_request_size);
- *     if (status != UCS_INPROGRESS) {
- *         return status;
- *     }
- *
- *     do {
- *         ucp_worker_progress(worker);
- *         status = ucp_request_check_status(request + ucp_request_size);
- *     } while (status == UCS_INPROGRESS);
- *
- *     return status;
- * }
- * @endcode
- *
- * @note The user should not modify any part of the @a buffer after this
- *       operation is called, until the operation completes.
- *
- *
- * @param [in]  ep          Destination endpoint handle.
- * @param [in]  buffer      Pointer to the message buffer (payload).
- * @param [in]  count       Number of elements to send
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag.
- * @param [in]  req         Request handle allocated by the user. There should
- *                          be at least UCP request size bytes of available
- *                          space before the @a req. The size of UCP request
- *                          can be obtained by @ref ucp_context_query function.
- *
- * @return UCS_OK           - The send operation was completed immediately.
- * @return UCS_INPROGRESS   - The send was not completed and is in progress.
- *                            @ref ucp_request_check_status() should be used to
- *                            monitor @a req status.
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_tag_send_nbr(ucp_ep_h ep, const void *buffer, size_t count,
-                              ucp_datatype_t datatype, ucp_tag_t tag, void *req);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking synchronous tagged-send operation.
- *
- * Same as @ref ucp_tag_send_nb, except the request completes only after there
- * is a remote tag match on the message (which does not always mean the remote
- * receive has been completed). This function never completes "in-place", and
- * always returns a request handle.
- *
- * @note The user should not modify any part of the @a buffer after this
- *       operation is called, until the operation completes.
- * @note Returns @ref UCS_ERR_UNSUPPORTED if @ref UCP_ERR_HANDLING_MODE_PEER is
- *       enabled. This is a temporary implementation-related constraint that
- *       will be addressed in future releases.
- *
- * @param [in]  ep          Destination endpoint handle.
- * @param [in]  buffer      Pointer to the message buffer (payload).
- * @param [in]  count       Number of elements to send
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          send operation is completed.
- *
- * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
- * @return otherwise        - Operation was scheduled for send and can be
- *                          completed in any point in time. The request handle
- *                          is returned to the application in order to track
- *                          progress of the message. The application is
- *                          responsible for releasing the handle using
- *                          @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_tag_send_sync_nb(ucp_ep_h ep, const void *buffer, size_t count,
-                                      ucp_datatype_t datatype, ucp_tag_t tag,
-                                      ucp_send_callback_t cb);
 
 
 /**
@@ -3573,53 +3194,6 @@ ucs_status_ptr_t ucp_tag_send_sync_nbx(ucp_ep_h ep, const void *buffer,
  *        user-supplied buffer.
  *
  * This routine receives data that is described by the local address @a buffer,
- * size @a count, and @a datatype object on the endpoint @a ep. The routine is
- * non-blocking and therefore returns immediately. The receive operation is
- * considered complete when the message is delivered to the buffer. If data is
- * not immediately available, the operation will be scheduled for receive and
- * a request handle will be returned. In order to notify the application about
- * completion of a scheduled receive operation, the UCP library will invoke
- * the call-back @a cb when data is in the receive buffer and ready for
- * application access. If the receive operation cannot be started, the routine
- * returns an error.
- *
- * @param [in]     ep       UCP endpoint that is used for the receive operation.
- * @param [in]     buffer   Pointer to the buffer to receive the data.
- * @param [in]     count    Number of elements to receive into @a buffer.
- * @param [in]     datatype Datatype descriptor for the elements in the buffer.
- * @param [in]     cb       Callback function that is invoked whenever the
- *                          receive operation is completed and the data is ready
- *                          in the receive @a buffer. It is important to note
- *                          that the call-back is only invoked in a case when
- *                          the operation cannot be completed immediately.
- * @param [out]    length   Size of the received data in bytes. The value is
- *                          valid only if return code is UCS_OK.
- * @note                    The amount of data received, in bytes, is always an
- *                          integral multiple of the @a datatype size.
- * @param [in]     flags    Flags defined in @ref ucp_stream_recv_flags_t.
- *
- * @return NULL                 - The receive operation was completed
- *                                immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
- * @return otherwise            - Operation was scheduled for receive. A request
- *                                handle is returned to the application in order
- *                                to track progress of the operation.
- *                                The application is responsible for releasing
- *                                the handle by calling the
- *                                @ref ucp_request_free routine.
- */
-ucs_status_ptr_t ucp_stream_recv_nb(ucp_ep_h ep, void *buffer, size_t count,
-                                    ucp_datatype_t datatype,
-                                    ucp_stream_recv_callback_t cb,
-                                    size_t *length, unsigned flags);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking stream receive operation of structured data into a
- *        user-supplied buffer.
- *
- * This routine receives data that is described by the local address @a buffer,
  * size @a count object on the endpoint @a ep. The routine is non-blocking
  * and therefore returns immediately. The receive operation is considered
  * complete when the message is delivered to the buffer. If the receive
@@ -3687,83 +3261,6 @@ ucs_status_ptr_t ucp_stream_recv_nbx(ucp_ep_h ep, void *buffer, size_t count,
  *       and thus avoiding extra memory copy operations.
  */
 ucs_status_ptr_t ucp_stream_recv_data_nb(ucp_ep_h ep, size_t *length);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking tagged-receive operation.
- *
- * This routine receives a message that is described by the local address @a
- * buffer, size @a count, and @a datatype object on the @a worker. The tag
- * value of the receive message has to match the @a tag and @a tag_mask values,
- * where the @a tag_mask indicates which bits of the tag have to be matched. The
- * routine is non-blocking and therefore returns immediately. The receive
- * operation is considered completed when the message is delivered to the @a
- * buffer.  In order to notify the application about completion of the receive
- * operation the UCP library will invoke the call-back @a cb when the received
- * message is in the receive buffer and ready for application access.  If the
- * receive operation cannot be stated the routine returns an error.
- *
- * @note This routine cannot return UCS_OK. It always returns a request
- *       handle or an error.
- *
- * @param [in]  worker      UCP worker that is used for the receive operation.
- * @param [in]  buffer      Pointer to the buffer to receive the data.
- * @param [in]  count       Number of elements to receive
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag to expect.
- * @param [in]  tag_mask    Bit mask that indicates the bits that are used for
- *                          the matching of the incoming tag
- *                          against the expected tag.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          receive operation is completed and the data is ready
- *                          in the receive @a buffer.
- *
- * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
- * @return otherwise          - Operation was scheduled for receive. The request
- *                              handle is returned to the application in order
- *                              to track progress of the operation. The
- *                              application is responsible for releasing the
- *                              handle using @ref ucp_request_free
- *                              "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_tag_recv_nb(ucp_worker_h worker, void *buffer, size_t count,
-                                 ucp_datatype_t datatype, ucp_tag_t tag,
-                                 ucp_tag_t tag_mask, ucp_tag_recv_callback_t cb);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking tagged-receive operation.
- *
- * This routine receives a message that is described by the local address @a
- * buffer, size @a count, and @a datatype object on the @a worker. The tag
- * value of the receive message has to match the @a tag and @a tag_mask values,
- * where the @a tag_mask indicates which bits of the tag have to be matched. The
- * routine is non-blocking and therefore returns immediately. The receive
- * operation is considered completed when the message is delivered to the @a
- * buffer. In order to monitor completion of the operation
- * @ref ucp_request_check_status or @ref ucp_tag_recv_request_test should be
- * used.
- *
- * @param [in]  worker      UCP worker that is used for the receive operation.
- * @param [in]  buffer      Pointer to the buffer to receive the data.
- * @param [in]  count       Number of elements to receive
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  tag         Message tag to expect.
- * @param [in]  tag_mask    Bit mask that indicates the bits that are used for
- *                          the matching of the incoming tag
- *                          against the expected tag.
- * @param [in]  req         Request handle allocated by the user. There should
- *                          be at least UCP request size bytes of available
- *                          space before the @a req. The size of UCP request
- *                          can be obtained by @ref ucp_context_query function.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_tag_recv_nbr(ucp_worker_h worker, void *buffer, size_t count,
-                              ucp_datatype_t datatype, ucp_tag_t tag,
-                              ucp_tag_t tag_mask, void *req);
 
 
 /**
@@ -3858,45 +3355,6 @@ ucp_tag_message_h ucp_tag_probe_nb(ucp_worker_h worker, ucp_tag_t tag,
  * @brief Non-blocking receive operation for a probed message.
  *
  * This routine receives a message that is described by the local address @a
- * buffer, size @a count, @a message handle, and @a datatype object on the @a
- * worker. The @a message handle can be obtained by calling the @ref
- * ucp_tag_probe_nb "ucp_tag_probe_nb()" routine. The @ref ucp_tag_msg_recv_nb
- * "ucp_tag_msg_recv_nb()" routine is non-blocking and therefore returns
- * immediately. The receive operation is considered completed when the message
- * is delivered to the @a buffer. In order to notify the application about
- * completion of the receive operation the UCP library will invoke the
- * call-back @a cb when the received message is in the receive buffer and ready
- * for application access. If the receive operation cannot be started the
- * routine returns an error.
- *
- * @param [in]  worker      UCP worker that is used for the receive operation.
- * @param [in]  buffer      Pointer to the buffer that will receive the data.
- * @param [in]  count       Number of elements to receive
- * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
- * @param [in]  message     Message handle.
- * @param [in]  cb          Callback function that is invoked whenever the
- *                          receive operation is completed and the data is ready
- *                          in the receive @a buffer.
- *
- * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
- * @return otherwise          - Operation was scheduled for receive. The request
- *                              handle is returned to the application in order
- *                              to track progress of the operation. The
- *                              application is responsible for releasing the
- *                              handle using @ref ucp_request_free
- *                              "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_tag_msg_recv_nb(ucp_worker_h worker, void *buffer,
-                                     size_t count, ucp_datatype_t datatype,
-                                     ucp_tag_message_h message,
-                                     ucp_tag_recv_callback_t cb);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking receive operation for a probed message.
- *
- * This routine receives a message that is described by the local address @a
  * buffer, size @a count, and @a message handle on the @a worker.
  * The @a message handle can be obtained by calling the @ref
  * ucp_tag_probe_nb "ucp_tag_probe_nb()" routine. The @ref ucp_tag_msg_recv_nbx
@@ -3925,82 +3383,6 @@ ucs_status_ptr_t ucp_tag_msg_recv_nb(ucp_worker_h worker, void *buffer,
 ucs_status_ptr_t ucp_tag_msg_recv_nbx(ucp_worker_h worker, void *buffer,
                                       size_t count, ucp_tag_message_h message,
                                       const ucp_request_param_t *param);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking implicit remote memory put operation.
- *
- * This routine initiates a storage of contiguous block of data that is
- * described by the local address @a buffer in the remote contiguous memory
- * region described by @a remote_addr address and the @ref ucp_rkey_h "memory
- * handle" @a rkey. The routine returns immediately and @b does @b not
- * guarantee re-usability of the source address @e buffer. If the operation is
- * completed immediately the routine return UCS_OK, otherwise UCS_INPROGRESS
- * or an error is returned to user.
- *
- * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
- * in order to guarantee re-usability of the source address @e buffer.
- *
- * @param [in]  ep           Remote endpoint handle.
- * @param [in]  buffer       Pointer to the local source address.
- * @param [in]  length       Length of the data (in bytes) stored under the
- *                           source address.
- * @param [in]  remote_addr  Pointer to the destination remote memory address
- *                           to write to.
- * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
-                         uint64_t remote_addr, ucp_rkey_h rkey);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking remote memory put operation.
- *
- * This routine initiates a storage of contiguous block of data that is
- * described by the local address @a buffer in the remote contiguous memory
- * region described by @a remote_addr address and the @ref ucp_rkey_h "memory
- * handle" @a rkey.  The routine returns immediately and @b does @b not
- * guarantee re-usability of the source address @e buffer. If the operation is
- * completed immediately the routine return UCS_OK, otherwise UCS_INPROGRESS
- * or an error is returned to user. If the put operation completes immediately,
- * the routine returns UCS_OK and the call-back routine @a cb is @b not
- * invoked. If the operation is @b not completed immediately and no error is
- * reported, then the UCP library will schedule invocation of the call-back
- * routine @a cb upon completion of the put operation. In other words, the
- * completion of a put operation can be signaled by the return code or
- * execution of the call-back.
- *
- * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
- * in order to guarantee re-usability of the source address @e buffer.
- *
- * @param [in]  ep           Remote endpoint handle.
- * @param [in]  buffer       Pointer to the local source address.
- * @param [in]  length       Length of the data (in bytes) stored under the
- *                           source address.
- * @param [in]  remote_addr  Pointer to the destination remote memory address
- *                           to write to.
- * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address.
- * @param [in]  cb           Call-back function that is invoked whenever the
- *                           put operation is completed and the local buffer
- *                           can be modified. Does not guarantee remote
- *                           completion.
- *
- * @return NULL                 - The operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
- * @return otherwise            - Operation was scheduled and can be
- *                              completed at any point in time. The request handle
- *                              is returned to the application in order to track
- *                              progress of the operation. The application is
- *                              responsible for releasing the handle using
- *                              @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_put_nb(ucp_ep_h ep, const void *buffer, size_t length,
-                            uint64_t remote_addr, ucp_rkey_h rkey,
-                            ucp_send_callback_t cb);
 
 
 /**
@@ -4060,81 +3442,6 @@ ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
 
 /**
  * @ingroup UCP_COMM
- * @brief Non-blocking implicit remote memory get operation.
- *
- * This routine initiate a load of contiguous block of data that is described
- * by the remote memory address @a remote_addr and the @ref ucp_rkey_h "memory handle"
- * @a rkey in the local contiguous memory region described by @a buffer
- * address. The routine returns immediately and @b does @b not guarantee that
- * remote data is loaded and stored under the local address @e buffer.
- *
- * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()" in order
- * guarantee that remote data is loaded and stored under the local address
- * @e buffer.
- *
- * @param [in]  ep           Remote endpoint handle.
- * @param [in]  buffer       Pointer to the local destination address.
- * @param [in]  length       Length of the data (in bytes) stored under the
- *                           destination address.
- * @param [in]  remote_addr  Pointer to the source remote memory address
- *                           to read from.
- * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
-                         uint64_t remote_addr, ucp_rkey_h rkey);
-
-/**
- * @ingroup UCP_COMM
- * @brief Non-blocking remote memory get operation.
- *
- * This routine initiates a load of a contiguous block of data that is
- * described by the remote memory address @a remote_addr and the @ref ucp_rkey_h
- * "memory handle" @a rkey in the local contiguous memory region described
- * by @a buffer address. The routine returns immediately and @b does @b not
- * guarantee that remote data is loaded and stored under the local address @e
- * buffer. If the operation is completed immediately the routine return UCS_OK,
- * otherwise UCS_INPROGRESS or an error is returned to user. If the get
- * operation completes immediately, the routine returns UCS_OK and the
- * call-back routine @a cb is @b not invoked. If the operation is @b not
- * completed immediately and no error is reported, then the UCP library will
- * schedule invocation of the call-back routine @a cb upon completion of the
- * get operation. In other words, the completion of a get operation can be
- * signaled by the return code or execution of the call-back.
- *
- * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
- * in order to guarantee re-usability of the source address @e buffer.
- *
- * @param [in]  ep           Remote endpoint handle.
- * @param [in]  buffer       Pointer to the local destination address.
- * @param [in]  length       Length of the data (in bytes) stored under the
- *                           destination address.
- * @param [in]  remote_addr  Pointer to the source remote memory address
- *                           to read from.
- * @param [in]  rkey         Remote memory key associated with the
- *                           remote memory address.
- * @param [in]  cb           Call-back function that is invoked whenever the
- *                           get operation is completed and the data is
- *                           visible to the local process.
- *
- * @return NULL                 - The operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
- * @return otherwise            - Operation was scheduled and can be
- *                              completed at any point in time. The request handle
- *                              is returned to the application in order to track
- *                              progress of the operation. The application is
- *                              responsible for releasing the handle using
- *                              @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
-                            uint64_t remote_addr, ucp_rkey_h rkey,
-                            ucp_send_callback_t cb);
-
-
-/**
- * @ingroup UCP_COMM
  * @brief Non-blocking remote memory get operation.
  *
  * This routine initiates a load of a contiguous block of data that is
@@ -4182,84 +3489,6 @@ ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
 ucs_status_ptr_t ucp_get_nbx(ucp_ep_h ep, void *buffer, size_t count,
                              uint64_t remote_addr, ucp_rkey_h rkey,
                              const ucp_request_param_t *param);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Post an atomic memory operation.
- *
- * This routine posts an atomic memory operation to a remote value.
- * The remote value is described by the combination of the remote
- * memory address @a remote_addr and the @ref ucp_rkey_h "remote memory handle"
- * @a rkey.
- * Return from the function does not guarantee completion. A user must
- * call @ref ucp_ep_flush_nb or @ref ucp_worker_flush_nb to guarantee that the
- * remote value has been updated.
- *
- * @param [in] ep          UCP endpoint.
- * @param [in] opcode      One of @ref ucp_atomic_post_op_t.
- * @param [in] value       Source operand for the atomic operation.
- * @param [in] op_size     Size of value in bytes
- * @param [in] remote_addr Remote address to operate on.
- * @param [in] rkey        Remote key handle for the remote memory address.
- *
- * @return Error code as defined by @ref ucs_status_t
- */
-ucs_status_t ucp_atomic_post(ucp_ep_h ep, ucp_atomic_post_op_t opcode, uint64_t value,
-                             size_t op_size, uint64_t remote_addr, ucp_rkey_h rkey);
-
-
-/**
- * @ingroup UCP_COMM
- * @brief Post an atomic fetch operation.
- *
- * This routine will post an atomic fetch operation to remote memory.
- * The remote value is described by the combination of the remote
- * memory address @a remote_addr and the @ref ucp_rkey_h "remote memory handle"
- * @a rkey.
- * The routine is non-blocking and therefore returns immediately. However the
- * actual atomic operation may be delayed. The atomic operation is not considered complete
- * until the values in remote and local memory are completed. If the atomic operation
- * completes immediately, the routine returns UCS_OK and the call-back routine
- * @a cb is @b not invoked. If the operation is @b not completed immediately and no
- * error is reported, then the UCP library will schedule invocation of the call-back
- * routine @a cb upon completion of the atomic operation. In other words, the completion
- * of an atomic operation can be signaled by the return code or execution of the call-back.
- *
- * @note The user should not modify any part of the @a result after this
- *       operation is called, until the operation completes.
- *
- * @param [in] ep          UCP endpoint.
- * @param [in] opcode      One of @ref ucp_atomic_fetch_op_t.
- * @param [in] value       Source operand for atomic operation. In the case of CSWAP
- *                         this is the conditional for the swap. For SWAP this is
- *                         the value to be placed in remote memory.
- * @param [inout] result   Local memory address to store resulting fetch to.
- *                         In the case of CSWAP the value in result will be
- *                         swapped into the @a remote_addr if the condition
- *                         is true.
- * @param [in] op_size     Size of value in bytes and pointer type for result
- * @param [in] remote_addr Remote address to operate on.
- * @param [in] rkey        Remote key handle for the remote memory address.
- * @param [in] cb          Call-back function that is invoked whenever the
- *                         send operation is completed. It is important to note
- *                         that the call-back function is only invoked in a case when
- *                         the operation cannot be completed in place.
- *
- * @return NULL                 - The operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
- * @return otherwise            - Operation was scheduled and can be
- *                              completed at any point in time. The request handle
- *                              is returned to the application in order to track
- *                              progress of the operation. The application is
- *                              responsible for releasing the handle using
- *                              @ref ucp_request_free "ucp_request_free()" routine.
- */
-ucs_status_ptr_t
-ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,
-                    uint64_t value, void *result, size_t op_size,
-                    uint64_t remote_addr, ucp_rkey_h rkey,
-                    ucp_send_callback_t cb);
 
 
 /**
@@ -4386,6 +3615,7 @@ ucs_status_t ucp_tag_recv_request_test(void *request, ucp_tag_recv_info_t *info)
  * @return Error code as defined by @ref ucs_status_t
  */
 ucs_status_t ucp_stream_recv_request_test(void *request, size_t *length_p);
+
 
 /**
  * @ingroup UCP_COMM
@@ -4539,39 +3769,6 @@ ucs_status_t ucp_worker_fence(ucp_worker_h worker);
  * @ref ucp_worker_fence "ucp_worker_fence()"
  *
  * @param [in] worker    UCP worker.
- * @param [in] flags     Flags for flush operation. Reserved for future use.
- * @param [in] cb        Callback which will be called when the flush operation
- *                       completes.
- *
- * @return NULL             - The flush operation was completed immediately.
- * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
- * @return otherwise        - Flush operation was scheduled and can be completed
- *                          in any point in time. The request handle is returned
- *                          to the application in order to track progress. The
- *                          application is responsible for releasing the handle
- *                          using @ref ucp_request_free "ucp_request_free()"
- *                          routine.
- */
-ucs_status_ptr_t ucp_worker_flush_nb(ucp_worker_h worker, unsigned flags,
-                                     ucp_send_callback_t cb);
-
-
-/**
- * @ingroup UCP_WORKER
- *
- * @brief Flush outstanding AMO and RMA operations on the @ref ucp_worker_h
- * "worker"
- *
- * This routine flushes all outstanding AMO and RMA communications on the
- * @ref ucp_worker_h "worker". All the AMO and RMA operations issued on the
- * @a worker prior to this call are completed both at the origin and at the
- * target when this call returns.
- *
- * @note For description of the differences between @ref ucp_worker_flush_nb
- * "flush" and @ref ucp_worker_fence "fence" operations please see
- * @ref ucp_worker_fence "ucp_worker_fence()"
- *
- * @param [in] worker    UCP worker.
  * @param [in] param     Operation parameters, see @ref ucp_request_param_t
  *
  * @return NULL                 - The flush operation was completed immediately.
@@ -4639,8 +3836,8 @@ typedef struct ucp_ep_attr {
     struct sockaddr_storage remote_sockaddr;
 
     /**
-     * Structure defining an array containing transport and device names used 
-     * by this endpoint. The caller is responsible for allocation and 
+     * Structure defining an array containing transport and device names used
+     * by this endpoint. The caller is responsible for allocation and
      * deallocation of this array.
      */
     ucp_transports_t        transports;

--- a/src/ucp/api/ucp_compat.h
+++ b/src/ucp/api/ucp_compat.h
@@ -499,6 +499,868 @@ ucs_status_t ucp_atomic_cswap64(ucp_ep_h ep, uint64_t compare, uint64_t swap,
 ucs_status_ptr_t ucp_ep_modify_nb(ucp_ep_h ep, const ucp_ep_params_t *params);
 
 
+/**
+ * @ingroup UCP_WORKER
+ * @brief Get the address of the worker object.
+ *
+ * @deprecated Use @ref ucp_worker_query with the flag
+ *             @ref UCP_WORKER_ATTR_FIELD_ADDRESS in order to obtain the worker
+ *             address.
+ *
+ * This routine returns the address of the worker object.  This address can be
+ * passed to remote instances of the UCP library in order to connect to this
+ * worker. The memory for the address handle is allocated by this function, and
+ * must be released by using @ref ucp_worker_release_address
+ * "ucp_worker_release_address()" routine.
+ *
+ * @param [in]  worker            Worker object whose address to return.
+ * @param [out] address_p         A pointer to the worker address.
+ * @param [out] address_length_p  The size in bytes of the address.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_worker_get_address(ucp_worker_h worker,
+                                    ucp_address_t **address_p,
+                                    size_t *address_length_p);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ *
+ * @brief Non-blocking @ref ucp_ep_h "endpoint" closure.
+ *
+ * @deprecated Use @ref ucp_ep_close_nbx instead.
+ *
+ * This routine releases the @ref ucp_ep_h "endpoint". The endpoint closure
+ * process depends on the selected @a mode.
+ *
+ * @param [in]  ep      Handle to the endpoint to close.
+ * @param [in]  mode    One from @ref ucp_ep_close_mode value.
+ *
+ * @return UCS_OK           - The endpoint is closed successfully.
+ * @return UCS_PTR_IS_ERR(_ptr) - The closure failed and an error code indicates
+ *                                the transport level status. However, resources
+ *                                are released and the @a endpoint can no longer
+ *                                be used.
+ * @return otherwise        - The closure process is started, and can be
+ *                            completed at any point in time. A request handle
+ *                            is returned to the application in order to track
+ *                            progress of the endpoint closure. The application
+ *                            is responsible for releasing the handle using the
+ *                            @ref ucp_request_free routine.
+ *
+ * @note @ref ucp_ep_close_nb replaces deprecated @ref ucp_disconnect_nb and
+ *       @ref ucp_ep_destroy
+ */
+ucs_status_ptr_t ucp_ep_close_nb(ucp_ep_h ep, unsigned mode);
+
+
+/**
+ * @ingroup UCP_ENDPOINT
+ *
+ * @brief Non-blocking flush of outstanding AMO and RMA operations on the
+ * @ref ucp_ep_h "endpoint".
+ *
+ * @deprecated Use @ref ucp_ep_flush_nbx instead.
+ *
+ * This routine flushes all outstanding AMO and RMA communications on the
+ * @ref ucp_ep_h "endpoint". All the AMO and RMA operations issued on the
+ * @a ep prior to this call are completed both at the origin and at the target
+ * @ref ucp_ep_h "endpoint" when this call returns.
+ *
+ * @param [in] ep        UCP endpoint.
+ * @param [in] flags     Flags for flush operation. Reserved for future use.
+ * @param [in] cb        Callback which will be called when the flush operation
+ *                       completes.
+ *
+ * @return NULL             - The flush operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
+ * @return otherwise        - Flush operation was scheduled and can be completed
+ *                          in any point in time. The request handle is returned
+ *                          to the application in order to track progress. The
+ *                          application is responsible for releasing the handle
+ *                          using @ref ucp_request_free "ucp_request_free()"
+ *                          routine.
+ */
+ucs_status_ptr_t ucp_ep_flush_nb(ucp_ep_h ep, unsigned flags,
+                                 ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_WORKER
+ * @brief Add user defined callback for Active Message.
+ *
+ * @deprecated Use @ref ucp_worker_set_am_recv_handler instead.
+ *
+ * This routine installs a user defined callback to handle incoming Active
+ * Messages with a specific id. This callback is called whenever an Active
+ * Message that was sent from the remote peer by @ref ucp_am_send_nb is
+ * received on this worker.
+ *
+ * @param [in]  worker      UCP worker on which to set the Active Message
+ *                          handler.
+ * @param [in]  id          Active Message id.
+ * @param [in]  cb          Active Message callback. NULL to clear.
+ * @param [in]  arg         Active Message argument, which will be passed
+ *                          in to every invocation of the callback as the
+ *                          arg argument.
+ * @param [in]  flags       Dictates how an Active Message is handled on the
+ *                          remote endpoint. Currently only
+ *                          UCP_AM_FLAG_WHOLE_MSG is supported, which
+ *                          indicates the callback will not be invoked
+ *                          until all data has arrived.
+ *
+ * @return error code if the worker does not support Active Messages or
+ *         requested callback flags.
+ */
+ucs_status_t ucp_worker_set_am_handler(ucp_worker_h worker, uint16_t id,
+                                       ucp_am_callback_t cb, void *arg,
+                                       uint32_t flags);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Send Active Message.
+ *
+ * @deprecated Use @ref ucp_am_send_nbx instead.
+ *
+ * This routine sends an Active Message to an ep. It does not support
+ * CUDA memory.
+ *
+ * @param [in]  ep          UCP endpoint where the Active Message will be run.
+ * @param [in]  id          Active Message id. Specifies which registered
+ *                          callback to run.
+ * @param [in]  buffer      Pointer to the data to be sent to the target node
+ *                          of the Active Message.
+ * @param [in]  count       Number of elements to send.
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  cb          Callback that is invoked upon completion of the
+ *                          data transfer if it is not completed immediately.
+ * @param [in]  flags       Operation flags as defined by @ref ucp_send_am_flags.
+ *
+ * @return NULL             Active Message was sent immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) Error sending Active Message.
+ * @return otherwise        Pointer to request, and Active Message is known
+ *                          to be completed after cb is run.
+ */
+ucs_status_ptr_t ucp_am_send_nb(ucp_ep_h ep, uint16_t id,
+                                const void *buffer, size_t count,
+                                ucp_datatype_t datatype,
+                                ucp_send_callback_t cb, unsigned flags);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking stream send operation.
+ *
+ * @deprecated Use @ref ucp_stream_send_nbx instead.
+ *
+ * This routine sends data that is described by the local address @a buffer,
+ * size @a count, and @a datatype object to the destination endpoint @a ep.
+ * The routine is non-blocking and therefore returns immediately, however
+ * the actual send operation may be delayed. The send operation is considered
+ * completed when it is safe to reuse the source @e buffer. If the send
+ * operation is completed immediately the routine returns UCS_OK and the
+ * callback function @a cb is @b not invoked. If the operation is
+ * @b not completed immediately and no error reported, then the UCP library will
+ * schedule invocation of the callback @a cb upon completion of the send
+ * operation. In other words, the completion of the operation will be signaled
+ * either by the return code or by the callback.
+ *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
+ *
+ * @param [in]  ep          Destination endpoint handle.
+ * @param [in]  buffer      Pointer to the message buffer (payload).
+ * @param [in]  count       Number of elements to send.
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          send operation is completed. It is important to note
+ *                          that the callback is only invoked in the event that
+ *                          the operation cannot be completed in place.
+ * @param [in]  flags       Reserved for future use.
+ *
+ * @return NULL             - The send operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
+ * @return otherwise        - Operation was scheduled for send and can be
+ *                          completed in any point in time. The request handle
+ *                          is returned to the application in order to track
+ *                          progress of the message. The application is
+ *                          responsible for releasing the handle using
+ *                          @ref ucp_request_free routine.
+ */
+ucs_status_ptr_t ucp_stream_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
+                                    ucp_datatype_t datatype, ucp_send_callback_t cb,
+                                    unsigned flags);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking stream receive operation of structured data into a
+ *        user-supplied buffer.
+ *
+ * @deprecated Use @ref ucp_stream_recv_nbx instead.
+ *
+ * This routine receives data that is described by the local address @a buffer,
+ * size @a count, and @a datatype object on the endpoint @a ep. The routine is
+ * non-blocking and therefore returns immediately. The receive operation is
+ * considered complete when the message is delivered to the buffer. If data is
+ * not immediately available, the operation will be scheduled for receive and
+ * a request handle will be returned. In order to notify the application about
+ * completion of a scheduled receive operation, the UCP library will invoke
+ * the call-back @a cb when data is in the receive buffer and ready for
+ * application access. If the receive operation cannot be started, the routine
+ * returns an error.
+ *
+ * @param [in]     ep       UCP endpoint that is used for the receive operation.
+ * @param [in]     buffer   Pointer to the buffer to receive the data.
+ * @param [in]     count    Number of elements to receive into @a buffer.
+ * @param [in]     datatype Datatype descriptor for the elements in the buffer.
+ * @param [in]     cb       Callback function that is invoked whenever the
+ *                          receive operation is completed and the data is ready
+ *                          in the receive @a buffer. It is important to note
+ *                          that the call-back is only invoked in a case when
+ *                          the operation cannot be completed immediately.
+ * @param [out]    length   Size of the received data in bytes. The value is
+ *                          valid only if return code is UCS_OK.
+ * @note                    The amount of data received, in bytes, is always an
+ *                          integral multiple of the @a datatype size.
+ * @param [in]     flags    Flags defined in @ref ucp_stream_recv_flags_t.
+ *
+ * @return NULL                 - The receive operation was completed
+ *                                immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
+ * @return otherwise            - Operation was scheduled for receive. A request
+ *                                handle is returned to the application in order
+ *                                to track progress of the operation.
+ *                                The application is responsible for releasing
+ *                                the handle by calling the
+ *                                @ref ucp_request_free routine.
+ */
+ucs_status_ptr_t ucp_stream_recv_nb(ucp_ep_h ep, void *buffer, size_t count,
+                                    ucp_datatype_t datatype,
+                                    ucp_stream_recv_callback_t cb,
+                                    size_t *length, unsigned flags);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking tagged-send operations
+ *
+ * @deprecated Use @ref ucp_tag_send_nbx instead.
+ *
+ * This routine sends a messages that is described by the local address @a
+ * buffer, size @a count, and @a datatype object to the destination endpoint
+ * @a ep. Each message is associated with a @a tag value that is used for
+ * message matching on the @ref ucp_tag_recv_nb "receiver". The routine is
+ * non-blocking and therefore returns immediately, however the actual send
+ * operation may be delayed. The send operation is considered completed when
+ * it is safe to reuse the source @e buffer. If the send operation is
+ * completed immediately the routine return UCS_OK and the call-back function
+ * @a cb is @b not invoked. If the operation is @b not completed immediately
+ * and no error reported then the UCP library will schedule to invoke the
+ * call-back @a cb whenever the send operation will be completed. In other
+ * words, the completion of a message can be signaled by the return code or
+ * the call-back.
+ *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
+ *
+ * @param [in]  ep          Destination endpoint handle.
+ * @param [in]  buffer      Pointer to the message buffer (payload).
+ * @param [in]  count       Number of elements to send
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          send operation is completed. It is important to note
+ *                          that the call-back is only invoked in a case when
+ *                          the operation cannot be completed in place.
+ *
+ * @return NULL            - The send operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
+ * @return otherwise        - Operation was scheduled for send and can be
+ *                          completed in any point in time. The request handle
+ *                          is returned to the application in order to track
+ *                          progress of the message. The application is
+ *                          responsible for releasing the handle using
+ *                          @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_tag_send_nb(ucp_ep_h ep, const void *buffer, size_t count,
+                                 ucp_datatype_t datatype, ucp_tag_t tag,
+                                 ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking tagged-send operations with user provided request
+ *
+ * @deprecated Use @ref ucp_tag_send_nbx with the flag
+ *             @ref UCP_OP_ATTR_FIELD_REQUEST instead.
+ *
+ * This routine provides a convenient and efficient way to implement a
+ * blocking send pattern. It also completes requests faster than
+ * @ref ucp_tag_send_nb() because:
+ * @li it always uses eager protocol to send data up to the
+ *     rendezvous threshold.
+ * @li its rendezvous threshold is higher than the one used by
+ *     the @ref ucp_tag_send_nb(). The threshold is controlled by
+ *     the @b UCX_SEND_NBR_RNDV_THRESH environment variable.
+ * @li its request handling is simpler. There is no callback and no need
+ *     to allocate and free requests. In fact request can be allocated by
+ *     caller on the stack.
+ *
+ * This routine sends a messages that is described by the local address @a
+ * buffer, size @a count, and @a datatype object to the destination endpoint
+ * @a ep. Each message is associated with a @a tag value that is used for
+ * message matching on the @ref ucp_tag_recv_nbr "receiver".
+ *
+ * The routine is non-blocking and therefore returns immediately, however
+ * the actual send operation may be delayed. The send operation is considered
+ * completed when it is safe to reuse the source @e buffer. If the send
+ * operation is completed immediately the routine returns UCS_OK.
+ *
+ * If the operation is @b not completed immediately and no error reported
+ * then the UCP library will fill a user provided @a req and
+ * return UCS_INPROGRESS status. In order to monitor completion of the
+ * operation @ref ucp_request_check_status() should be used.
+ *
+ * Following pseudo code implements a blocking send function:
+ * @code
+ * MPI_send(...)
+ * {
+ *     char *request;
+ *     ucs_status_t status;
+ *
+ *     // allocate request on the stack
+ *     // ucp_context_query() was used to get ucp_request_size
+ *     request = alloca(ucp_request_size);
+ *
+ *     // note: make sure that there is enough memory before the
+ *     // request handle
+ *     status = ucp_tag_send_nbr(ep, ..., request + ucp_request_size);
+ *     if (status != UCS_INPROGRESS) {
+ *         return status;
+ *     }
+ *
+ *     do {
+ *         ucp_worker_progress(worker);
+ *         status = ucp_request_check_status(request + ucp_request_size);
+ *     } while (status == UCS_INPROGRESS);
+ *
+ *     return status;
+ * }
+ * @endcode
+ *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
+ *
+ *
+ * @param [in]  ep          Destination endpoint handle.
+ * @param [in]  buffer      Pointer to the message buffer (payload).
+ * @param [in]  count       Number of elements to send
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag.
+ * @param [in]  req         Request handle allocated by the user. There should
+ *                          be at least UCP request size bytes of available
+ *                          space before the @a req. The size of UCP request
+ *                          can be obtained by @ref ucp_context_query function.
+ *
+ * @return UCS_OK           - The send operation was completed immediately.
+ * @return UCS_INPROGRESS   - The send was not completed and is in progress.
+ *                            @ref ucp_request_check_status() should be used to
+ *                            monitor @a req status.
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_tag_send_nbr(ucp_ep_h ep, const void *buffer, size_t count,
+                              ucp_datatype_t datatype, ucp_tag_t tag, void *req);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking synchronous tagged-send operation.
+ *
+ * @deprecated Use @ref ucp_tag_send_sync_nbx instead.
+ *
+ * Same as @ref ucp_tag_send_nb, except the request completes only after there
+ * is a remote tag match on the message (which does not always mean the remote
+ * receive has been completed). This function never completes "in-place", and
+ * always returns a request handle.
+ *
+ * @note The user should not modify any part of the @a buffer after this
+ *       operation is called, until the operation completes.
+ * @note Returns @ref UCS_ERR_UNSUPPORTED if @ref UCP_ERR_HANDLING_MODE_PEER is
+ *       enabled. This is a temporary implementation-related constraint that
+ *       will be addressed in future releases.
+ *
+ * @param [in]  ep          Destination endpoint handle.
+ * @param [in]  buffer      Pointer to the message buffer (payload).
+ * @param [in]  count       Number of elements to send
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          send operation is completed.
+ *
+ * @return UCS_PTR_IS_ERR(_ptr) - The send operation failed.
+ * @return otherwise        - Operation was scheduled for send and can be
+ *                          completed in any point in time. The request handle
+ *                          is returned to the application in order to track
+ *                          progress of the message. The application is
+ *                          responsible for releasing the handle using
+ *                          @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_tag_send_sync_nb(ucp_ep_h ep, const void *buffer, size_t count,
+                                      ucp_datatype_t datatype, ucp_tag_t tag,
+                                      ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking tagged-receive operation.
+ *
+ * @deprecated Use @ref ucp_tag_recv_nbx instead.
+ *
+ * This routine receives a message that is described by the local address @a
+ * buffer, size @a count, and @a datatype object on the @a worker. The tag
+ * value of the receive message has to match the @a tag and @a tag_mask values,
+ * where the @a tag_mask indicates which bits of the tag have to be matched. The
+ * routine is non-blocking and therefore returns immediately. The receive
+ * operation is considered completed when the message is delivered to the @a
+ * buffer.  In order to notify the application about completion of the receive
+ * operation the UCP library will invoke the call-back @a cb when the received
+ * message is in the receive buffer and ready for application access.  If the
+ * receive operation cannot be stated the routine returns an error.
+ *
+ * @note This routine cannot return UCS_OK. It always returns a request
+ *       handle or an error.
+ *
+ * @param [in]  worker      UCP worker that is used for the receive operation.
+ * @param [in]  buffer      Pointer to the buffer to receive the data.
+ * @param [in]  count       Number of elements to receive
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag to expect.
+ * @param [in]  tag_mask    Bit mask that indicates the bits that are used for
+ *                          the matching of the incoming tag
+ *                          against the expected tag.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          receive operation is completed and the data is ready
+ *                          in the receive @a buffer.
+ *
+ * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
+ * @return otherwise          - Operation was scheduled for receive. The request
+ *                              handle is returned to the application in order
+ *                              to track progress of the operation. The
+ *                              application is responsible for releasing the
+ *                              handle using @ref ucp_request_free
+ *                              "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_tag_recv_nb(ucp_worker_h worker, void *buffer, size_t count,
+                                 ucp_datatype_t datatype, ucp_tag_t tag,
+                                 ucp_tag_t tag_mask, ucp_tag_recv_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking tagged-receive operation.
+ *
+ * @deprecated Use @ref ucp_tag_recv_nbx with the flag
+ *             @ref UCP_OP_ATTR_FIELD_REQUEST instead.
+ *
+ * This routine receives a message that is described by the local address @a
+ * buffer, size @a count, and @a datatype object on the @a worker. The tag
+ * value of the receive message has to match the @a tag and @a tag_mask values,
+ * where the @a tag_mask indicates which bits of the tag have to be matched. The
+ * routine is non-blocking and therefore returns immediately. The receive
+ * operation is considered completed when the message is delivered to the @a
+ * buffer. In order to monitor completion of the operation
+ * @ref ucp_request_check_status or @ref ucp_tag_recv_request_test should be
+ * used.
+ *
+ * @param [in]  worker      UCP worker that is used for the receive operation.
+ * @param [in]  buffer      Pointer to the buffer to receive the data.
+ * @param [in]  count       Number of elements to receive
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  tag         Message tag to expect.
+ * @param [in]  tag_mask    Bit mask that indicates the bits that are used for
+ *                          the matching of the incoming tag
+ *                          against the expected tag.
+ * @param [in]  req         Request handle allocated by the user. There should
+ *                          be at least UCP request size bytes of available
+ *                          space before the @a req. The size of UCP request
+ *                          can be obtained by @ref ucp_context_query function.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_tag_recv_nbr(ucp_worker_h worker, void *buffer, size_t count,
+                              ucp_datatype_t datatype, ucp_tag_t tag,
+                              ucp_tag_t tag_mask, void *req);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking receive operation for a probed message.
+ *
+ * @deprecated Use @ref ucp_tag_recv_nbx instead.
+ *
+ * This routine receives a message that is described by the local address @a
+ * buffer, size @a count, @a message handle, and @a datatype object on the @a
+ * worker. The @a message handle can be obtained by calling the @ref
+ * ucp_tag_probe_nb "ucp_tag_probe_nb()" routine. The @ref ucp_tag_msg_recv_nb
+ * "ucp_tag_msg_recv_nb()" routine is non-blocking and therefore returns
+ * immediately. The receive operation is considered completed when the message
+ * is delivered to the @a buffer. In order to notify the application about
+ * completion of the receive operation the UCP library will invoke the
+ * call-back @a cb when the received message is in the receive buffer and ready
+ * for application access. If the receive operation cannot be started the
+ * routine returns an error.
+ *
+ * @param [in]  worker      UCP worker that is used for the receive operation.
+ * @param [in]  buffer      Pointer to the buffer that will receive the data.
+ * @param [in]  count       Number of elements to receive
+ * @param [in]  datatype    Datatype descriptor for the elements in the buffer.
+ * @param [in]  message     Message handle.
+ * @param [in]  cb          Callback function that is invoked whenever the
+ *                          receive operation is completed and the data is ready
+ *                          in the receive @a buffer.
+ *
+ * @return UCS_PTR_IS_ERR(_ptr) - The receive operation failed.
+ * @return otherwise          - Operation was scheduled for receive. The request
+ *                              handle is returned to the application in order
+ *                              to track progress of the operation. The
+ *                              application is responsible for releasing the
+ *                              handle using @ref ucp_request_free
+ *                              "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_tag_msg_recv_nb(ucp_worker_h worker, void *buffer,
+                                     size_t count, ucp_datatype_t datatype,
+                                     ucp_tag_message_h message,
+                                     ucp_tag_recv_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking implicit remote memory put operation.
+ *
+ * @deprecated Use @ref ucp_put_nbx without passing the flag
+ *             @ref UCP_OP_ATTR_FIELD_CALLBACK instead. If a request pointer
+ *             is returned, release it immediately by @ref ucp_request_free.
+ *
+ * This routine initiates a storage of contiguous block of data that is
+ * described by the local address @a buffer in the remote contiguous memory
+ * region described by @a remote_addr address and the @ref ucp_rkey_h "memory
+ * handle" @a rkey. The routine returns immediately and @b does @b not
+ * guarantee re-usability of the source address @e buffer. If the operation is
+ * completed immediately the routine return UCS_OK, otherwise UCS_INPROGRESS
+ * or an error is returned to user.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
+ * in order to guarantee re-usability of the source address @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local source address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           source address.
+ * @param [in]  remote_addr  Pointer to the destination remote memory address
+ *                           to write to.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote memory address.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_put_nbi(ucp_ep_h ep, const void *buffer, size_t length,
+                         uint64_t remote_addr, ucp_rkey_h rkey);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking remote memory put operation.
+ *
+ * @deprecated Use @ref ucp_put_nbx instead.
+ *
+ * This routine initiates a storage of contiguous block of data that is
+ * described by the local address @a buffer in the remote contiguous memory
+ * region described by @a remote_addr address and the @ref ucp_rkey_h "memory
+ * handle" @a rkey.  The routine returns immediately and @b does @b not
+ * guarantee re-usability of the source address @e buffer. If the operation is
+ * completed immediately the routine return UCS_OK, otherwise UCS_INPROGRESS
+ * or an error is returned to user. If the put operation completes immediately,
+ * the routine returns UCS_OK and the call-back routine @a cb is @b not
+ * invoked. If the operation is @b not completed immediately and no error is
+ * reported, then the UCP library will schedule invocation of the call-back
+ * routine @a cb upon completion of the put operation. In other words, the
+ * completion of a put operation can be signaled by the return code or
+ * execution of the call-back.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
+ * in order to guarantee re-usability of the source address @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local source address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           source address.
+ * @param [in]  remote_addr  Pointer to the destination remote memory address
+ *                           to write to.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote memory address.
+ * @param [in]  cb           Call-back function that is invoked whenever the
+ *                           put operation is completed and the local buffer
+ *                           can be modified. Does not guarantee remote
+ *                           completion.
+ *
+ * @return NULL                 - The operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
+ * @return otherwise            - Operation was scheduled and can be
+ *                              completed at any point in time. The request handle
+ *                              is returned to the application in order to track
+ *                              progress of the operation. The application is
+ *                              responsible for releasing the handle using
+ *                              @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_put_nb(ucp_ep_h ep, const void *buffer, size_t length,
+                            uint64_t remote_addr, ucp_rkey_h rkey,
+                            ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking implicit remote memory get operation.
+ *
+ * @deprecated Use @ref ucp_get_nbx without passing the flag
+ *             @ref UCP_OP_ATTR_FIELD_CALLBACK instead. If a request pointer
+ *             is returned, release it immediately by @ref ucp_request_free.
+ *
+ * This routine initiate a load of contiguous block of data that is described
+ * by the remote memory address @a remote_addr and the @ref ucp_rkey_h "memory handle"
+ * @a rkey in the local contiguous memory region described by @a buffer
+ * address. The routine returns immediately and @b does @b not guarantee that
+ * remote data is loaded and stored under the local address @e buffer.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()" in order
+ * guarantee that remote data is loaded and stored under the local address
+ * @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local destination address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           destination address.
+ * @param [in]  remote_addr  Pointer to the source remote memory address
+ *                           to read from.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote memory address.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_get_nbi(ucp_ep_h ep, void *buffer, size_t length,
+                         uint64_t remote_addr, ucp_rkey_h rkey);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Non-blocking remote memory get operation.
+ *
+ * @deprecated Use @ref ucp_get_nbx instead.
+ *
+ * This routine initiates a load of a contiguous block of data that is
+ * described by the remote memory address @a remote_addr and the @ref ucp_rkey_h
+ * "memory handle" @a rkey in the local contiguous memory region described
+ * by @a buffer address. The routine returns immediately and @b does @b not
+ * guarantee that remote data is loaded and stored under the local address @e
+ * buffer. If the operation is completed immediately the routine return UCS_OK,
+ * otherwise UCS_INPROGRESS or an error is returned to user. If the get
+ * operation completes immediately, the routine returns UCS_OK and the
+ * call-back routine @a cb is @b not invoked. If the operation is @b not
+ * completed immediately and no error is reported, then the UCP library will
+ * schedule invocation of the call-back routine @a cb upon completion of the
+ * get operation. In other words, the completion of a get operation can be
+ * signaled by the return code or execution of the call-back.
+ *
+ * @note A user can use @ref ucp_worker_flush_nb "ucp_worker_flush_nb()"
+ * in order to guarantee re-usability of the source address @e buffer.
+ *
+ * @param [in]  ep           Remote endpoint handle.
+ * @param [in]  buffer       Pointer to the local destination address.
+ * @param [in]  length       Length of the data (in bytes) stored under the
+ *                           destination address.
+ * @param [in]  remote_addr  Pointer to the source remote memory address
+ *                           to read from.
+ * @param [in]  rkey         Remote memory key associated with the
+ *                           remote memory address.
+ * @param [in]  cb           Call-back function that is invoked whenever the
+ *                           get operation is completed and the data is
+ *                           visible to the local process.
+ *
+ * @return NULL                 - The operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
+ * @return otherwise            - Operation was scheduled and can be
+ *                              completed at any point in time. The request handle
+ *                              is returned to the application in order to track
+ *                              progress of the operation. The application is
+ *                              responsible for releasing the handle using
+ *                              @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t ucp_get_nb(ucp_ep_h ep, void *buffer, size_t length,
+                            uint64_t remote_addr, ucp_rkey_h rkey,
+                            ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Atomic operation requested for ucp_atomic_post
+ *
+ * @deprecated Use @ref ucp_atomic_op_nbx and @ref ucp_atomic_op_t instead.
+ *
+ * This enumeration defines which atomic memory operation should be
+ * performed by the ucp_atomic_post family of functions. All of these are
+ * non-fetching atomics and will not result in a request handle.
+ */
+typedef enum {
+    UCP_ATOMIC_POST_OP_ADD, /**< Atomic add */
+    UCP_ATOMIC_POST_OP_AND, /**< Atomic and */
+    UCP_ATOMIC_POST_OP_OR,  /**< Atomic or  */
+    UCP_ATOMIC_POST_OP_XOR, /**< Atomic xor */
+    UCP_ATOMIC_POST_OP_LAST
+} ucp_atomic_post_op_t;
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Post an atomic memory operation.
+ *
+ * @deprecated Use @ref ucp_atomic_op_nbx without the flag
+ *             @ref UCP_OP_ATTR_FIELD_REPLY_BUFFER instead.
+ *
+ * This routine posts an atomic memory operation to a remote value.
+ * The remote value is described by the combination of the remote
+ * memory address @a remote_addr and the @ref ucp_rkey_h "remote memory handle"
+ * @a rkey.
+ * Return from the function does not guarantee completion. A user must
+ * call @ref ucp_ep_flush_nb or @ref ucp_worker_flush_nb to guarantee that the
+ * remote value has been updated.
+ *
+ * @param [in] ep          UCP endpoint.
+ * @param [in] opcode      One of @ref ucp_atomic_post_op_t.
+ * @param [in] value       Source operand for the atomic operation.
+ * @param [in] op_size     Size of value in bytes
+ * @param [in] remote_addr Remote address to operate on.
+ * @param [in] rkey        Remote key handle for the remote memory address.
+ *
+ * @return Error code as defined by @ref ucs_status_t
+ */
+ucs_status_t ucp_atomic_post(ucp_ep_h ep, ucp_atomic_post_op_t opcode, uint64_t value,
+                             size_t op_size, uint64_t remote_addr, ucp_rkey_h rkey);
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Atomic operation requested for ucp_atomic_fetch
+ *
+ * @deprecated Use @ref ucp_atomic_op_nbx and @ref ucp_atomic_op_t instead.
+ *
+ * This enumeration defines which atomic memory operation should be performed
+ * by the ucp_atomic_fetch family of functions. All of these functions
+ * will fetch data from the remote node.
+ */
+typedef enum {
+    UCP_ATOMIC_FETCH_OP_FADD,  /**< Atomic Fetch and add    */
+    UCP_ATOMIC_FETCH_OP_SWAP,  /**< Atomic swap             */
+    UCP_ATOMIC_FETCH_OP_CSWAP, /**< Atomic conditional swap */
+    UCP_ATOMIC_FETCH_OP_FAND,  /**< Atomic Fetch and and    */
+    UCP_ATOMIC_FETCH_OP_FOR,   /**< Atomic Fetch and or     */
+    UCP_ATOMIC_FETCH_OP_FXOR,  /**< Atomic Fetch and xor    */
+    UCP_ATOMIC_FETCH_OP_LAST
+} ucp_atomic_fetch_op_t;
+
+
+/**
+ * @ingroup UCP_COMM
+ * @brief Post an atomic fetch operation.
+ *
+ * @deprecated Use @ref ucp_atomic_op_nbx with the flag
+ *             @ref UCP_OP_ATTR_FIELD_REPLY_BUFFER instead.
+ *
+ * This routine will post an atomic fetch operation to remote memory.
+ * The remote value is described by the combination of the remote
+ * memory address @a remote_addr and the @ref ucp_rkey_h "remote memory handle"
+ * @a rkey.
+ * The routine is non-blocking and therefore returns immediately. However the
+ * actual atomic operation may be delayed. The atomic operation is not considered complete
+ * until the values in remote and local memory are completed. If the atomic operation
+ * completes immediately, the routine returns UCS_OK and the call-back routine
+ * @a cb is @b not invoked. If the operation is @b not completed immediately and no
+ * error is reported, then the UCP library will schedule invocation of the call-back
+ * routine @a cb upon completion of the atomic operation. In other words, the completion
+ * of an atomic operation can be signaled by the return code or execution of the call-back.
+ *
+ * @note The user should not modify any part of the @a result after this
+ *       operation is called, until the operation completes.
+ *
+ * @param [in] ep          UCP endpoint.
+ * @param [in] opcode      One of @ref ucp_atomic_fetch_op_t.
+ * @param [in] value       Source operand for atomic operation. In the case of CSWAP
+ *                         this is the conditional for the swap. For SWAP this is
+ *                         the value to be placed in remote memory.
+ * @param [inout] result   Local memory address to store resulting fetch to.
+ *                         In the case of CSWAP the value in result will be
+ *                         swapped into the @a remote_addr if the condition
+ *                         is true.
+ * @param [in] op_size     Size of value in bytes and pointer type for result
+ * @param [in] remote_addr Remote address to operate on.
+ * @param [in] rkey        Remote key handle for the remote memory address.
+ * @param [in] cb          Call-back function that is invoked whenever the
+ *                         send operation is completed. It is important to note
+ *                         that the call-back function is only invoked in a case when
+ *                         the operation cannot be completed in place.
+ *
+ * @return NULL                 - The operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The operation failed.
+ * @return otherwise            - Operation was scheduled and can be
+ *                              completed at any point in time. The request handle
+ *                              is returned to the application in order to track
+ *                              progress of the operation. The application is
+ *                              responsible for releasing the handle using
+ *                              @ref ucp_request_free "ucp_request_free()" routine.
+ */
+ucs_status_ptr_t
+ucp_atomic_fetch_nb(ucp_ep_h ep, ucp_atomic_fetch_op_t opcode,
+                    uint64_t value, void *result, size_t op_size,
+                    uint64_t remote_addr, ucp_rkey_h rkey,
+                    ucp_send_callback_t cb);
+
+
+/**
+ * @ingroup UCP_WORKER
+ *
+ * @brief Flush outstanding AMO and RMA operations on the @ref ucp_worker_h
+ * "worker"
+ *
+ * @deprecated Use @ref ucp_worker_flush_nbx instead.
+ *
+ * This routine flushes all outstanding AMO and RMA communications on the
+ * @ref ucp_worker_h "worker". All the AMO and RMA operations issued on the
+ * @a worker prior to this call are completed both at the origin and at the
+ * target when this call returns.
+ *
+ * @note For description of the differences between @ref ucp_worker_flush_nb
+ * "flush" and @ref ucp_worker_fence "fence" operations please see
+ * @ref ucp_worker_fence "ucp_worker_fence()"
+ *
+ * @param [in] worker    UCP worker.
+ * @param [in] flags     Flags for flush operation. Reserved for future use.
+ * @param [in] cb        Callback which will be called when the flush operation
+ *                       completes.
+ *
+ * @return NULL             - The flush operation was completed immediately.
+ * @return UCS_PTR_IS_ERR(_ptr) - The flush operation failed.
+ * @return otherwise        - Flush operation was scheduled and can be completed
+ *                          in any point in time. The request handle is returned
+ *                          to the application in order to track progress. The
+ *                          application is responsible for releasing the handle
+ *                          using @ref ucp_request_free "ucp_request_free()"
+ *                          routine.
+ */
+ucs_status_ptr_t ucp_worker_flush_nb(ucp_worker_h worker, unsigned flags,
+                                     ucp_send_callback_t cb);
+
+
 END_C_DECLS
 
 #endif

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -1129,6 +1129,7 @@ UCS_PROFILE_FUNC(ucs_status_ptr_t, ucp_am_recv_data_nbx,
         req->recv.length   = ucp_dt_length(datatype, count, buffer,
                                            &req->recv.state);
         req->recv.mem_type = mem_type;
+        req->recv.op_attr  = param->op_attr_mask;
         req->recv.am.desc  = desc;
         rts                = data_desc;
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -286,13 +286,18 @@ static inline int ucp_mem_map_is_allocate(const ucp_mem_map_params_t *params)
            (params->flags & UCP_MEM_MAP_ALLOCATE);
 }
 
-void ucp_memh_dereg(ucp_context_h context, ucp_mem_h memh, ucp_md_map_t md_map)
+static void ucp_memh_dereg(ucp_context_h context, ucp_mem_h memh,
+                           ucp_md_map_t md_map)
 {
     ucp_md_index_t md_index;
     ucs_status_t status;
 
     /* Unregister from all memory domains */
     ucs_for_each_bit(md_index, md_map) {
+        ucs_assertv(md_index != memh->alloc_md_index,
+                    "memh %p: md_index %u alloc_md_index %u", memh, md_index,
+                    memh->alloc_md_index);
+
         ucs_trace("de-registering memh[%d]=%p", md_index, memh->uct[md_index]);
         ucs_assert(context->tl_mds[md_index].attr.cap.flags & UCT_MD_FLAG_REG);
         status = uct_md_mem_dereg(context->tl_mds[md_index].md,
@@ -304,6 +309,33 @@ void ucp_memh_dereg(ucp_context_h context, ucp_mem_h memh, ucp_md_map_t md_map)
         }
 
         memh->uct[md_index] = NULL;
+    }
+}
+
+void ucp_memh_unmap(ucp_context_h context, ucp_mem_h memh, ucp_md_map_t md_map)
+{
+    uct_allocated_memory_t mem;
+    ucs_status_t status;
+
+    mem.address = ucp_memh_address(memh);
+    mem.length  = ucp_memh_length(memh);
+    mem.method  = memh->alloc_method;
+
+    if (mem.method == UCT_ALLOC_METHOD_MD) {
+        ucs_assert(memh->alloc_md_index != UCP_NULL_RESOURCE);
+        mem.md   = context->tl_mds[memh->alloc_md_index].md;
+        mem.memh = memh->uct[memh->alloc_md_index];
+        md_map  &= ~UCS_BIT(memh->alloc_md_index);
+    }
+
+    ucp_memh_dereg(context, memh, md_map);
+
+    /* If the memory was also allocated, release it */
+    if (memh->alloc_method != UCT_ALLOC_METHOD_LAST) {
+        status = uct_mem_free(&mem);
+        if (status != UCS_OK) {
+            ucs_warn("failed to free: %s", ucs_status_string(status));
+        }
     }
 }
 
@@ -950,32 +982,9 @@ static ucs_status_t ucp_mem_rcache_mem_reg_cb(void *context, ucs_rcache_t *rcach
 static void ucp_mem_rcache_mem_dereg_cb(void *ctx, ucs_rcache_t *rcache,
                                         ucs_rcache_region_t *rregion)
 {
-    ucp_mem_h memh        = ucs_derived_of(rregion, ucp_mem_t);
-    ucp_md_map_t md_map   = memh->md_map;
-    ucp_context_h context = ctx;
-    uct_allocated_memory_t mem;
-    ucs_status_t status;
+    ucp_mem_h memh = ucs_derived_of(rregion, ucp_mem_t);
 
-    mem.address = ucp_memh_address(memh);
-    mem.length  = ucp_memh_length(memh);
-    mem.method  = memh->alloc_method;
-
-    if (mem.method == UCT_ALLOC_METHOD_MD) {
-        ucs_assert(memh->alloc_md_index != UCP_NULL_RESOURCE);
-        mem.md   = context->tl_mds[memh->alloc_md_index].md;
-        mem.memh = memh->uct[memh->alloc_md_index];
-        md_map  &= ~UCS_BIT(memh->alloc_md_index);
-    }
-
-    ucp_memh_dereg(context, memh, md_map);
-
-    /* If the memory was also allocated, release it */
-    if (memh->alloc_method != UCT_ALLOC_METHOD_LAST) {
-        status = uct_mem_free(&mem);
-        if (status != UCS_OK) {
-            ucs_warn("failed to free: %s", ucs_status_string(status));
-        }
-    }
+    ucp_memh_unmap((ucp_context_h)ctx, memh, memh->md_map);
 }
 
 static void ucp_mem_rcache_dump_region_cb(void *rcontext, ucs_rcache_t *rcache,

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -134,7 +134,8 @@ ucs_status_t ucp_memh_get_slow(ucp_context_h context, void *address,
                                ucp_md_map_t reg_md_map, unsigned uct_flags,
                                ucp_mem_h *memh_p);
 
-void ucp_memh_dereg(ucp_context_h context, ucp_mem_h memh, ucp_md_map_t md_map);
+void ucp_memh_unmap(ucp_context_h context, ucp_mem_h memh,
+                    ucp_md_map_t md_map);
 
 ucs_status_t ucp_mem_rcache_init(ucp_context_h context);
 

--- a/src/ucp/core/ucp_mm.inl
+++ b/src/ucp/core/ucp_mm.inl
@@ -67,7 +67,7 @@ ucp_memh_put(ucp_context_h context, ucp_mem_h memh, int invalidate)
     }
 
     if (ucs_unlikely(context->rcache == NULL)) {
-        ucp_memh_dereg(context, memh, memh->md_map);
+        ucp_memh_unmap(context, memh, memh->md_map);
         ucs_free(memh);
         return;
     }

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -378,6 +378,7 @@ struct ucp_request {
             ucp_datatype_t        datatype; /* Receive type */
             size_t                length;   /* Total length, in bytes */
             ucs_memory_type_t     mem_type; /* Memory type */
+            uint32_t              op_attr;  /* Operation attributes */
             ucp_dt_state_t        state;
             ucp_worker_t          *worker;
             uct_tag_context_t     uct_ctx;  /* Transport offload context */

--- a/src/ucp/tag/tag_recv.c
+++ b/src/ucp/tag/tag_recv.c
@@ -132,7 +132,7 @@ ucp_tag_recv_common(ucp_worker_h worker, void *buffer, size_t count,
                                             &req->recv.state);
     req->recv.mem_type      = ucp_request_get_memory_type(worker->context, buffer,
                                                          req->recv.length, param);
-
+    req->recv.op_attr       = param->op_attr_mask;
     req->recv.tag.tag       = tag;
     req->recv.tag.tag_mask  = tag_mask;
     if (param->op_attr_mask & UCP_OP_ATTR_FIELD_CALLBACK) {

--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -364,12 +364,10 @@ void ucs_mem_region_destroy_internal(ucs_rcache_t *rcache,
 
     if (region->flags & UCS_RCACHE_REGION_FLAG_REGISTERED) {
         UCS_STATS_UPDATE_COUNTER(rcache->stats, UCS_RCACHE_DEREGS, 1);
-        {
-            UCS_PROFILE_CODE("mem_dereg") {
-                rcache->params.ops->mem_dereg(rcache->params.context, rcache,
-                region);
-            }
-        }
+        UCS_PROFILE_NAMED_CALL_VOID_ALWAYS("mem_dereg",
+                                           rcache->params.ops->mem_dereg,
+                                           rcache->params.context, rcache,
+                                           region);
     }
 
     if (!(rcache->params.flags & UCS_RCACHE_FLAG_NO_PFN_CHECK) &&
@@ -733,7 +731,7 @@ ucs_rcache_check_overlap(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
              * TODO: currently rcache is optimized for the case where most of
              * the regions have same protection.
              */
-            mem_prot = UCS_PROFILE_CALL(ucs_get_mem_prot, *start, *end);
+            mem_prot = UCS_PROFILE_CALL_ALWAYS(ucs_get_mem_prot, *start, *end);
             if (!ucs_test_all_flags(mem_prot, *prot)) {
                 ucs_rcache_region_trace(rcache, region,
                                         "do not merge "UCS_RCACHE_PROT_FMT
@@ -897,10 +895,9 @@ retry:
     ++distribution_bin->count;
     distribution_bin->total_size += region_size;
 
-    region->status = status =
-        UCS_PROFILE_NAMED_CALL("mem_reg", rcache->params.ops->mem_reg,
-                               rcache->params.context, rcache, arg, region,
-                               merged ? UCS_RCACHE_MEM_REG_HIDE_ERRORS : 0);
+    region->status = status = UCS_PROFILE_NAMED_CALL_ALWAYS(
+            "mem_reg", rcache->params.ops->mem_reg, rcache->params.context,
+            rcache, arg, region, merged ? UCS_RCACHE_MEM_REG_HIDE_ERRORS : 0);
     if (status != UCS_OK) {
         if (merged) {
             /* failure may be due to merge, because memory of the merged

--- a/src/ucs/profile/profile_off.h
+++ b/src/ucs/profile/profile_off.h
@@ -11,21 +11,17 @@
 
 #include <ucs/sys/compiler_def.h>
 
-
-#define UCS_PROFILE(...)                                    UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_SAMPLE(_name)                           UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_SCOPE_BEGIN()                           UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_SCOPE_END(_name)                        UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_CODE(_name)
-#define UCS_PROFILE_FUNC(_ret_type, _name, _arglist, ...)   _ret_type _name(__VA_ARGS__)
-#define UCS_PROFILE_FUNC_VOID(_name, _arglist, ...)         void _name(__VA_ARGS__)
-#define UCS_PROFILE_NAMED_CALL(_name, _func, ...)           _func(__VA_ARGS__)
-#define UCS_PROFILE_CALL(_func, ...)                        _func(__VA_ARGS__)
-#define UCS_PROFILE_NAMED_CALL_VOID(_name, _func, ...)      _func(__VA_ARGS__)
-#define UCS_PROFILE_CALL_VOID(_func, ...)                   _func(__VA_ARGS__)
-#define UCS_PROFILE_REQUEST_NEW(...)                        UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_REQUEST_EVENT(...)                      UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_REQUEST_EVENT_CHECK_STATUS(...)         UCS_EMPTY_STATEMENT
-#define UCS_PROFILE_REQUEST_FREE(...)                       UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_SAMPLE(...)                     UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_CODE(_, _code)                  _code
+#define UCS_PROFILE_FUNC(_ret_type, _name, _, ...)  _ret_type _name(__VA_ARGS__)
+#define UCS_PROFILE_FUNC_VOID(_name, _, ...)        void _name(__VA_ARGS__)
+#define UCS_PROFILE_NAMED_CALL(_name, _func, ...)   _func(__VA_ARGS__)
+#define UCS_PROFILE_CALL(_func, ...)                _func(__VA_ARGS__)
+#define UCS_PROFILE_NAMED_CALL_VOID                 UCS_PROFILE_NAMED_CALL
+#define UCS_PROFILE_CALL_VOID                       UCS_PROFILE_CALL
+#define UCS_PROFILE_REQUEST_NEW(...)                UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_REQUEST_EVENT(...)              UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_REQUEST_EVENT_CHECK_STATUS(...) UCS_EMPTY_STATEMENT
+#define UCS_PROFILE_REQUEST_FREE(...)               UCS_EMPTY_STATEMENT
 
 #endif

--- a/src/ucs/profile/profile_on.h
+++ b/src/ucs/profile/profile_on.h
@@ -11,277 +11,18 @@
 
 #include <ucs/sys/compiler_def.h>
 #include <ucs/sys/preprocessor.h>
-#include <ucs/config/global_opts.h>
-
 
 BEGIN_C_DECLS
 
-/** @file profile_on.h */
-
-/* Helper macro */
-#define _UCS_PROFILE_CTX_RECORD(_ctx, _type, _name, _param64, _param32, _loc_id_p) \
-    { \
-        if (*(_loc_id_p) != 0) { \
-            ucs_profile_record((_ctx), (_type), (_name), (_param64), \
-                               (_param32), __FILE__, __LINE__, __FUNCTION__, \
-                               (_loc_id_p)); \
-        } \
-    }
-
-
-/* Helper macro */
-#define __UCS_PROFILE_CTX_CODE(_ctx, _name, _loop_var) \
-    int _loop_var ; \
-    for (({ UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); _loop_var = 1;}); \
-         _loop_var; \
-         ({ UCS_PROFILE_CTX_SCOPE_END((_ctx), (_name)); _loop_var = 0;}))
-
-
-/* Helper macro */
-#define _UCS_PROFILE_CTX_CODE(_ctx, _name, _var_suffix) \
-    __UCS_PROFILE_CTX_CODE(_ctx, _name, UCS_PP_TOKENPASTE(loop, _var_suffix))
-
-
-/**
- * Record a profiling event.
- *
- * @param _ctx      Profiling context.
- * @param _type     Event type.
- * @param _name     Event name.
- * @param _param32  Custom 32-bit parameter.
- * @param _param64  Custom 64-bit parameter.
- */
-#define UCS_PROFILE_CTX_RECORD(_ctx, _type, _name, _param32, _param64) \
-    { \
-        static int loc_id = -1; \
-        _UCS_PROFILE_CTX_RECORD((_ctx), (_type), (_name), (_param32), \
-                                (_param64), &loc_id); \
-    }
-
-
-/**
- * Record a profiling sample event.
- *
- * @param _name   Event name.
- */
-#define UCS_PROFILE_SAMPLE(_name) \
-    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_SAMPLE, \
-                           (_name), 0, 0)
-
-
-/**
- * Record a scope-begin profiling event.
- *
- * @param _ctx  Profiling context.
- */
-#define UCS_PROFILE_CTX_SCOPE_BEGIN(_ctx) \
-    { \
-        UCS_PROFILE_CTX_RECORD((_ctx), UCS_PROFILE_TYPE_SCOPE_BEGIN, "", 0, 0); \
-        ucs_compiler_fence(); \
-    }
-
-
-/**
- * Record a scope-end profiling event.
- *
- * @param _ctx  Profiling context.
- * @param _name Scope name.
- */
-#define UCS_PROFILE_CTX_SCOPE_END(_ctx, _name) \
-    { \
-        ucs_compiler_fence(); \
-        UCS_PROFILE_CTX_RECORD((_ctx), UCS_PROFILE_TYPE_SCOPE_END, _name, 0, 0); \
-    }
-
-
-/**
- * Declare a profiled scope of code.
- *
- * Usage:
- *  UCS_PROFILE_CODE(<name>) {
- *     <code>
- *  }
- *
- * @param _name   Scope name.
- */
-#define UCS_PROFILE_CODE(_name) \
-    _UCS_PROFILE_CTX_CODE(ucs_profile_default_ctx, _name, UCS_PP_UNIQUE_ID)
-
-
-/**
- * Create a profiled function.
- *
- * Usage:
- *  _UCS_PROFILE_CTX_FUNC(ctx, <retval>, <name>, (a, b), int a, char b)
- *
- * @param _ctx        Profiling context.
- * @param _ret_type   Function return type.
- * @param _name       Function name.
- * @param _arglist    List of argument *names* only.
- * @param ...         Argument declarations (with types).
- */
-#define _UCS_PROFILE_CTX_FUNC(_ctx, _ret_type, _name, _arglist, ...) \
-    static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__); \
-    \
-    _ret_type _name(__VA_ARGS__) \
-    { \
-        _ret_type _ret; \
-        UCS_PROFILE_CTX_SCOPE_BEGIN(_ctx); \
-        _ret = _name##_inner _arglist; \
-        UCS_PROFILE_CTX_SCOPE_END(_ctx, #_name); \
-        return _ret; \
-    } \
-    static UCS_F_ALWAYS_INLINE _ret_type _name##_inner(__VA_ARGS__)
-
-
-/**
- * Create a profiled function. Uses default profile context.
- *
- * Usage:
- *  UCS_PROFILE_FUNC(<retval>, <name>, (a, b), int a, char b)
- *
- * @param _ret_type   Function return type.
- * @param _name       Function name.
- * @param _arglist    List of argument *names* only.
- * @param ...         Argument declarations (with types).
- */
-#define UCS_PROFILE_FUNC(_ret_type, _name, _arglist, ...) \
-    _UCS_PROFILE_CTX_FUNC(ucs_profile_default_ctx, _ret_type, _name, _arglist, ## __VA_ARGS__)
-
-
-/**
- * Create a profiled function whose return type is void.
- *
- * Usage:
- *  _UCS_PROFILE_CTX_FUNC_VOID(ctx, <name>, (a, b), int a, char b)
- *
- * @param _ctx        Profiling context.
- * @param _name       Function name.
- * @param _arglist    List of argument *names* only.
- * @param ...         Argument declarations (with types).
- */
-#define _UCS_PROFILE_CTX_FUNC_VOID(_ctx, _name, _arglist, ...) \
-    static UCS_F_ALWAYS_INLINE void _name##_inner(__VA_ARGS__); \
-    \
-    void _name(__VA_ARGS__) { \
-        UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); \
-        _name##_inner _arglist; \
-        UCS_PROFILE_CTX_SCOPE_END((_ctx), #_name); \
-    } \
-    static UCS_F_ALWAYS_INLINE void _name##_inner(__VA_ARGS__)
-
-
-/**
- * Create a profiled function whose return type is void. Uses default profile
- * context.
- *
- * Usage:
- *  UCS_PROFILE_FUNC_VOID(<name>, (a, b), int a, char b)
- *
- * @param _name       Function name.
- * @param _arglist    List of argument *names* only.
- * @param ...         Argument declarations (with types).
- */
-#define UCS_PROFILE_FUNC_VOID(_name, _arglist, ...) \
-    _UCS_PROFILE_CTX_FUNC_VOID(ucs_profile_default_ctx, _name, _arglist, ## __VA_ARGS__)
-
-
-/*
- * Profile a function call, and specify explicit name string for the profile.
- * Useful when calling a function by a pointer. Uses default profile context.
- *
- * Usage:
- *  _UCS_PROFILE_CTX_NAMED_CALL(ctx, "name", function, arg1, arg2)
- *
- * @param _name   Name string for the profile.
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define _UCS_PROFILE_CTX_NAMED_CALL(_ctx, _name, _func, ...) \
-    ({ \
-        ucs_typeof(_func(__VA_ARGS__)) retval; \
-        UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); \
-        retval = _func(__VA_ARGS__); \
-        UCS_PROFILE_CTX_SCOPE_END((_ctx), _name); \
-        retval; \
-    })
-
-
-/*
- * Profile a function call, and specify explicit name string for the profile.
- * Useful when calling a function by a pointer. Uses default profile context.
- *
- * Usage:
- *  UCS_PROFILE_NAMED_CALL("name", function, arg1, arg2)
- *
- * @param _name   Name string for the profile.
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define UCS_PROFILE_NAMED_CALL(_name, _func, ...) \
-    _UCS_PROFILE_CTX_NAMED_CALL(ucs_profile_default_ctx, _name, _func,  ## __VA_ARGS__)
-
-
-/*
- * Profile a function call.
- *
- * Usage:
- *  UCS_PROFILE_CALL(function, arg1, arg2)
- *
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define UCS_PROFILE_CALL(_func, ...) \
-    UCS_PROFILE_NAMED_CALL(#_func, _func, ## __VA_ARGS__)
-
-
-/*
- * Profile a function call which does not return a value, and specify explicit
- * name string for the profile. Useful when calling a function by a pointer.
- *
- * Usage:
- *  _UCS_PROFILE_CTX_NAMED_CALL_VOID(ctx, "name", function, arg1, arg2)
- *
- * @param _ctx    Profiling context.
- * @param _name   Name string for the profile.
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define _UCS_PROFILE_CTX_NAMED_CALL_VOID(_ctx, _name, _func, ...) \
-    { \
-        UCS_PROFILE_CTX_SCOPE_BEGIN((_ctx)); \
-        _func(__VA_ARGS__); \
-        UCS_PROFILE_CTX_SCOPE_END((_ctx), _name); \
-    }
-
-
-/*
- * Profile a function call which does not return a value, and specify explicit
- * name string for the profile. Useful when calling a function by a pointer.
- * Uses default profile context.
- *
- * Usage:
- *  UCS_PROFILE_NAMED_CALL_VOID("name", function, arg1, arg2)
- *
- * @param _name   Name string for the profile.
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define UCS_PROFILE_NAMED_CALL_VOID(_name, _func, ...) \
-    _UCS_PROFILE_CTX_NAMED_CALL_VOID(ucs_profile_default_ctx, _name, _func, ## __VA_ARGS__)
-
-
-/*
- * Profile a function call which does not return a value.
- *
- * Usage:
- *  UCS_PROFILE_CALL_VOID(function, arg1, arg2)
- *
- * @param _func   Function name.
- * @param ...     Function call arguments.
- */
-#define UCS_PROFILE_CALL_VOID(_func, ...) \
-    UCS_PROFILE_NAMED_CALL_VOID(#_func, _func, ## __VA_ARGS__)
+#define UCS_PROFILE_SAMPLE          UCS_PROFILE_SAMPLE_ALWAYS
+#define UCS_PROFILE_CODE            UCS_PROFILE_CODE_ALWAYS
+#define UCS_PROFILE_FUNC            UCS_PROFILE_FUNC_ALWAYS
+#define UCS_PROFILE_FUNC_VOID       UCS_PROFILE_FUNC_VOID_ALWAYS
+#define UCS_PROFILE_NAMED_CALL      UCS_PROFILE_NAMED_CALL_ALWAYS
+#define UCS_PROFILE_CALL            UCS_PROFILE_CALL_ALWAYS
+#define UCS_PROFILE_NAMED_CALL_VOID UCS_PROFILE_NAMED_CALL_VOID_ALWAYS
+#define UCS_PROFILE_CALL_VOID       UCS_PROFILE_CALL_VOID_ALWAYS
+#define UCS_PROFILE_REQUEST_EVENT   UCS_PROFILE_REQUEST_EVENT_ALWAYS
 
 
 /*
@@ -292,20 +33,9 @@ BEGIN_C_DECLS
  * @param _param32  Custom 32-bit parameter.
  */
 #define UCS_PROFILE_REQUEST_NEW(_req, _name, _param32) \
-    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_REQUEST_NEW, \
-                           (_name), (_param32), (uintptr_t)(_req));
-
-
-/*
- * Profile a request progress event.
- *
- * @param _req      Request pointer.
- * @param _name     Event name.
- * @param _param32  Custom 32-bit parameter.
- */
-#define UCS_PROFILE_REQUEST_EVENT(_req, _name, _param32) \
-    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_REQUEST_EVENT, \
-                           (_name), (_param32), (uintptr_t)(_req));
+    UCS_PROFILE_CTX_RECORD_ALWAYS(ucs_profile_default_ctx, \
+                                  UCS_PROFILE_TYPE_REQUEST_NEW, (_name), \
+                                  (_param32), (uintptr_t)(_req));
 
 
 /*
@@ -328,28 +58,9 @@ BEGIN_C_DECLS
  * @param _req      Request pointer.
  */
 #define UCS_PROFILE_REQUEST_FREE(_req) \
-    UCS_PROFILE_CTX_RECORD(ucs_profile_default_ctx, UCS_PROFILE_TYPE_REQUEST_FREE, \
-                           "", 0, (uintptr_t)(_req));
-
-
-/*
- * Store a new record with the given data.
- * SHOULD NOT be used directly - use UCS_PROFILE macros instead.
- * @param [in]     ctx         Global profile context.
- * @param [in]     type        Location type.
- * @param [in]     name        Location name.
- * @param [in]     param32     custom 32-bit parameter.
- * @param [in]     param64     custom 64-bit parameter.
- * @param [in]     file        Source file name.
- * @param [in]     line        Source line number.
- * @param [in]     function    Calling function name.
- * @param [in,out] loc_id_p    Variable used to maintain the location ID.
- */
-void ucs_profile_record(ucs_profile_context_t *ctx, ucs_profile_type_t type,
-                        const char *name, uint32_t param32, uint64_t param64,
-                        const char *file, int line, const char *function,
-                        volatile int *loc_id_p);
-
+    UCS_PROFILE_CTX_RECORD_ALWAYS(ucs_profile_default_ctx, \
+                                  UCS_PROFILE_TYPE_REQUEST_FREE, "", 0, \
+                                  (uintptr_t)(_req));
 
 END_C_DECLS
 

--- a/src/uct/base/uct_mem.c
+++ b/src/uct/base/uct_mem.c
@@ -440,8 +440,9 @@ static inline uct_iface_mp_priv_t* uct_iface_mp_priv(ucs_mpool_t *mp)
     return (uct_iface_mp_priv_t*)ucs_mpool_priv(mp);
 }
 
-UCS_PROFILE_FUNC(ucs_status_t, uct_iface_mp_chunk_alloc, (mp, size_p, chunk_p),
-                 ucs_mpool_t *mp, size_t *size_p, void **chunk_p)
+UCS_PROFILE_FUNC_ALWAYS(ucs_status_t, uct_iface_mp_chunk_alloc,
+                        (mp, size_p, chunk_p), ucs_mpool_t *mp, size_t *size_p,
+                        void **chunk_p)
 {
     uct_base_iface_t *iface = uct_iface_mp_priv(mp)->iface;
     uct_iface_mp_chunk_hdr_t *hdr;
@@ -469,8 +470,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_iface_mp_chunk_alloc, (mp, size_p, chunk_p),
     return UCS_OK;
 }
 
-UCS_PROFILE_FUNC_VOID(uct_iface_mp_chunk_release, (mp, chunk),
-                      ucs_mpool_t *mp, void *chunk)
+UCS_PROFILE_FUNC_VOID_ALWAYS(uct_iface_mp_chunk_release, (mp, chunk),
+                             ucs_mpool_t *mp, void *chunk)
 {
     uct_base_iface_t *iface = uct_iface_mp_priv(mp)->iface;
     uct_iface_mp_chunk_hdr_t *hdr;

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -17,6 +17,7 @@
 #include <uct/base/uct_md.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/arch/cpu.h>
+#include <ucs/profile/profile.h>
 #include <ucs/type/class.h>
 #include <ucs/type/cpu_set.h>
 #include <ucs/type/serialize.h>
@@ -962,9 +963,11 @@ ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
     uct_ib_iface_fill_attr(iface, attr);
 
 #if HAVE_DECL_IBV_CREATE_QP_EX
-    qp = ibv_create_qp_ex(dev->ibv_context, &attr->ibv);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp_ex, dev->ibv_context,
+                                 &attr->ibv);
 #else
-    qp = ibv_create_qp(uct_ib_iface_md(iface)->pd, &attr->ibv);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, uct_ib_iface_md(iface)->pd,
+                                 &attr->ibv);
 #endif
     if (qp == NULL) {
         ucs_error("iface=%p: failed to create %s QP "

--- a/src/uct/ib/dc/dc_mlx5.c
+++ b/src/uct/ib/dc/dc_mlx5.c
@@ -16,6 +16,7 @@
 #include <uct/ib/base/ib_device.h>
 #include <uct/ib/base/ib_log.h>
 #include <uct/ib/mlx5/ib_mlx5_log.h>
+#include <ucs/profile/profile.h>
 #include <ucs/vfs/base/vfs_cb.h>
 #include <ucs/vfs/base/vfs_obj.h>
 #include <uct/base/uct_md.h>
@@ -351,7 +352,8 @@ static ucs_status_t uct_dc_mlx5_iface_create_dci(uct_dc_mlx5_iface_t *iface,
     dv_attr.dc_init_attr.dct_access_key = UCT_IB_KEY;
     uct_rc_mlx5_common_fill_dv_qp_attr(&iface->super, &attr.super.ibv, &dv_attr,
                                        UCS_BIT(UCT_IB_DIR_TX));
-    qp = mlx5dv_create_qp(dev->ibv_context, &attr.super.ibv, &dv_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, dev->ibv_context,
+                                 &attr.super.ibv, &dv_attr);
     if (qp == NULL) {
         ucs_error("mlx5dv_create_qp("UCT_IB_IFACE_FMT", DCI): failed: %m",
                   UCT_IB_IFACE_ARG(ib_iface));

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -193,9 +193,11 @@ static ucs_status_t uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md,
     UCT_IB_MLX5DV_SET64(mkc, mkc, len, length);
     UCT_IB_MLX5DV_SET(create_mkey_in, in, translations_octword_actual_size, list_size);
 
-    mr = mlx5dv_devx_obj_create(md->super.dev.ibv_context, in,
-                                uct_ib_mlx5_calc_mkey_inlen(list_size),
-                                out, sizeof(out));
+    mr = UCS_PROFILE_NAMED_CALL_ALWAYS("devx_create_mkey",
+                                       mlx5dv_devx_obj_create,
+                                       md->super.dev.ibv_context, in,
+                                       uct_ib_mlx5_calc_mkey_inlen(list_size),
+                                       out, sizeof(out));
     if (mr == NULL) {
         ucs_debug("mlx5dv_devx_obj_create(CREATE_MKEY, mode=KSM) failed, syndrome %x: %m",
                   UCT_IB_MLX5DV_GET(create_mkey_out, out, syndrome));
@@ -1169,7 +1171,7 @@ static ucs_status_t uct_ib_mlx5dv_check_dc(uct_ib_device_t *dev)
     dv_attr.dc_init_attr.dct_access_key = UCT_IB_KEY;
 
     /* create DCT qp successful means DC is supported */
-    qp = mlx5dv_create_qp(ctx, &qp_attr, &dv_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, ctx, &qp_attr, &dv_attr);
     if (qp == NULL) {
         ucs_debug("%s: mlx5dv_create_qp(DCT) failed: %m",
                   uct_ib_device_name(dev));

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -246,14 +246,14 @@ uct_ib_mlx5_devx_reg_ksm_data_contig(uct_ib_mlx5_md_t *md, uct_ib_mlx5_mr_t *mr,
                                      off_t off, struct mlx5dv_devx_obj **mr_p,
                                      uint32_t *mkey)
 {
-    intptr_t addr           = (intptr_t)mr->super.ib->addr &
-                              ~(UCT_IB_MD_MAX_MR_SIZE - 1);
+    intptr_t addr = (intptr_t)mr->super.ib->addr & ~(UCT_IB_MD_MAX_MR_SIZE - 1);
     /* FW requires indirect atomic MR addr and length to be aligned
      * to max supported atomic argument size */
-    size_t length           = ucs_align_up(mr->super.ib->length +
-                              (intptr_t)mr->super.ib->addr - addr,
-                              md->super.dev.atomic_align);
-    int list_size           = ucs_div_round_up(length, UCT_IB_MD_MAX_MR_SIZE);
+    size_t length = ucs_align_up(mr->super.ib->length +
+                                 (intptr_t)mr->super.ib->addr - addr,
+                                 md->super.dev.atomic_align);
+    /* add off to workaround CREATE_MKEY range check issue */
+    int list_size = ucs_div_round_up(length + off, UCT_IB_MD_MAX_MR_SIZE);
     int i;
     char *in;
     void *klm;

--- a/src/uct/ib/rc/accel/rc_mlx5_common.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.c
@@ -14,6 +14,7 @@
 #include <uct/api/uct.h>
 #include <uct/ib/rc/base/rc_iface.h>
 #include <ucs/arch/bitops.h>
+#include <ucs/profile/profile.h>
 
 
 ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
@@ -341,7 +342,7 @@ uct_rc_mlx5_verbs_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     qp_init_attr.srq                 = iface->rx.srq.verbs.srq;
     qp_init_attr.cap.max_send_wr     = iface->tm.cmd_qp_len;
 
-    qp = ibv_create_qp(md->pd, &qp_init_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, md->pd, &qp_init_attr);
     if (qp == NULL) {
         ucs_error("failed to create TM control QP: %m");
         goto err_rd;

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -430,7 +430,7 @@ typedef struct uct_rc_mlx5_iface_common_config {
         size_t                           mp_num_strides;
     } tm;
     unsigned                             exp_backoff;
-    uint8_t                              log_ack_req_freq;
+    unsigned                             log_ack_req_freq;
     UCS_CONFIG_STRING_ARRAY_FIELD(types) srq_topo;
 } uct_rc_mlx5_iface_common_config_t;
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -762,7 +762,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
     self->super.config.fence_mode  = (uct_rc_fence_mode_t)rc_config->fence_mode;
     self->super.rx.srq.quota       = self->rx.srq.mask + 1;
     self->super.config.exp_backoff = mlx5_config->exp_backoff;
-    self->config.log_ack_req_freq  = mlx5_config->log_ack_req_freq;
+    self->config.log_ack_req_freq  = ucs_min(mlx5_config->log_ack_req_freq,
+                                             UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ);
 
     if ((rc_config->fence_mode == UCT_RC_FENCE_MODE_WEAK) ||
         ((rc_config->fence_mode == UCT_RC_FENCE_MODE_AUTO) &&
@@ -878,8 +879,6 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
 
     self->super.super.config.tx_moderation = ucs_min(config->super.tx_cq_moderation,
                                                      self->super.tx.bb_max / 4);
-    self->super.config.log_ack_req_freq    = ucs_min(config->super.log_ack_req_freq,
-                                                     UCT_RC_MLX5_MAX_LOG_ACK_REQ_FREQ);
 
     status = uct_rc_init_fc_thresh(&config->super, &self->super.super);
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -17,6 +17,7 @@
 #include <uct/base/uct_md.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/log.h>
+#include <ucs/profile/profile.h>
 
 #include "rc_mlx5.inl"
 
@@ -349,7 +350,8 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
     uct_rc_mlx5_common_fill_dv_qp_attr(iface, &attr->super.ibv, &dv_attr,
                                        UCS_BIT(UCT_IB_DIR_TX) |
                                        UCS_BIT(UCT_IB_DIR_RX));
-    qp->verbs.qp = mlx5dv_create_qp(dev->ibv_context, &attr->super.ibv, &dv_attr);
+    qp->verbs.qp = UCS_PROFILE_CALL_ALWAYS(mlx5dv_create_qp, dev->ibv_context,
+                                           &attr->super.ibv, &dv_attr);
     if (qp->verbs.qp == NULL) {
         ucs_error("mlx5dv_create_qp("UCT_IB_IFACE_FMT"): failed: %m",
                   UCT_IB_IFACE_ARG(ib_iface));

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -174,8 +174,6 @@ struct uct_rc_iface_config {
     unsigned                       tx_cq_moderation; /* How many TX messages are
                                                         batched to one CQE */
     unsigned                       tx_cq_len;
-    unsigned                       log_ack_req_freq; /* Log of requests ack
-                                                        frequency on DevX */
 };
 
 

--- a/src/uct/ib/rdmacm/rdmacm_cm_ep.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm_ep.c
@@ -13,6 +13,7 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/sys/sock.h>
 #include <ucs/async/async.h>
+#include <ucs/profile/profile.h>
 
 
 const char* uct_rdmacm_cm_ep_str(uct_rdmacm_cm_ep_t *cep, char *str,
@@ -341,7 +342,7 @@ uct_rdmacm_cm_create_dummy_qp(uct_rdmacm_cm_device_context_t *ctx,
     qp_init_attr.cap.max_send_sge = 1;
     qp_init_attr.cap.max_recv_sge = 1;
 
-    qp = ibv_create_qp(cep->id->pd, &qp_init_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, cep->id->pd, &qp_init_attr);
     if (qp == NULL) {
         ucs_error("failed to create a dummy ud qp. %m");
         return UCS_ERR_IO_ERROR;

--- a/src/uct/rocm/base/rocm_base.c
+++ b/src/uct/rocm/base/rocm_base.c
@@ -185,8 +185,15 @@ ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
     info.size = sizeof(hsa_amd_pointer_info_t);
     status = hsa_amd_pointer_info((void*)addr, &info, NULL, NULL, NULL);
     if ((status == HSA_STATUS_SUCCESS) &&
-        (info.type != HSA_EXT_POINTER_TYPE_UNKNOWN)) {
-        *mem_type_p = UCS_MEMORY_TYPE_ROCM;
+        (info.type == HSA_EXT_POINTER_TYPE_HSA)) {
+        hsa_device_type_t dev_type;
+
+        status = hsa_agent_get_info(info.agentOwner, HSA_AGENT_INFO_DEVICE, &dev_type);
+        if ((status == HSA_STATUS_SUCCESS) &&
+            (dev_type == HSA_DEVICE_TYPE_GPU)) {
+	    *mem_type_p = UCS_MEMORY_TYPE_ROCM;
+            return UCS_OK;
+        }
     }
 
     return UCS_OK;

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -252,8 +252,13 @@ uct_self_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
     }
 
     for (i = 0; i < self_md->num_devices; i++) {
-        ucs_snprintf_zero(devices[i].name, sizeof(devices->name), "%s%d",
-                          UCT_SM_DEVICE_NAME, i);
+        if (self_md->num_devices > 1) {
+            ucs_snprintf_zero(devices[i].name, sizeof(devices->name), "%s%d",
+                              UCT_SM_DEVICE_NAME, i);
+        } else {
+            ucs_strncpy_zero(devices[i].name, UCT_SM_DEVICE_NAME,
+                             sizeof(devices->name));
+        }
         devices[i].type       = UCT_DEVICE_TYPE_SELF;
         devices[i].sys_device = UCS_SYS_DEVICE_ID_UNKNOWN;
     }

--- a/test/apps/iodemo/Makefile.am
+++ b/test/apps/iodemo/Makefile.am
@@ -27,6 +27,7 @@ io_demo_CXXFLAGS = \
 io_demo_CPPFLAGS = $(BASE_CPPFLAGS) $(io_demo_CUDA_CPPFLAGS)
 
 io_demo_LDADD    = \
+	$(top_builddir)/src/ucm/libucm.la \
 	$(top_builddir)/src/ucs/libucs.la \
 	$(top_builddir)/src/uct/libuct.la \
 	$(top_builddir)/src/ucp/libucp.la \

--- a/test/apps/profiling/ucx_profiling.c
+++ b/test/apps/profiling/ucx_profiling.c
@@ -17,16 +17,14 @@ UCS_PROFILE_FUNC(double, calc_pi, (count), int count) {
     pi_d_4 = 0.0;
 
     /* Profile a block of code */
-    {
-        UCS_PROFILE_CODE("leibnitz") {
-            for (n = 0; n < count; ++n) {
-                pi_d_4 += pow(-1.0, n) / (2 * n + 1);
+    UCS_PROFILE_CODE("leibnitz", {
+        for (n = 0; n < count; ++n) {
+            pi_d_4 += pow(-1.0, n) / (2 * n + 1);
 
-                /* create a timestamp for each step */
-                UCS_PROFILE_SAMPLE("step");
-            }
+            /* create a timestamp for each step */
+            UCS_PROFILE_SAMPLE("step");
         }
-    }
+    });
 
     return pi_d_4 * 4.0;
 }

--- a/test/gtest/ucm/malloc_hook.cc
+++ b/test/gtest/ucm/malloc_hook.cc
@@ -302,8 +302,12 @@ private:
     typedef std::pair<void*, void*> range;
 
     bool is_ptr_in_range(void *ptr, size_t size, const std::vector<range> &ranges) {
-        for (std::vector<range>::const_iterator iter = ranges.begin(); iter != ranges.end(); ++iter) {
-            if ((ptr >= iter->first) && ((char*)ptr < iter->second)) {
+        uintptr_t p = (uintptr_t)ptr;
+        for (std::vector<range>::const_iterator iter = ranges.begin();
+             iter != ranges.end(); ++iter) {
+            uintptr_t begin = (uintptr_t)iter->first;
+            uintptr_t end   = (uintptr_t)iter->second;
+            if ((p >= begin) && (p < end)) {
                 return true;
             }
         }

--- a/test/gtest/ucp/test_ucp_mmap.cc
+++ b/test/gtest/ucp/test_ucp_mmap.cc
@@ -21,7 +21,8 @@ public:
     enum {
         VARIANT_DEFAULT,
         VARIANT_MAP_NONBLOCK,
-        VARIANT_PROTO_ENABLE
+        VARIANT_PROTO_ENABLE,
+        VARIANT_NO_RCACHE
     };
 
     static void
@@ -32,6 +33,8 @@ public:
                                "map_nb");
         add_variant_with_value(variants, UCP_FEATURE_RMA, VARIANT_PROTO_ENABLE,
                                "proto");
+        add_variant_with_value(variants, UCP_FEATURE_RMA, VARIANT_NO_RCACHE,
+                               "no_rcache");
     }
 
     virtual void init() {
@@ -43,6 +46,10 @@ public:
         sender().connect(&receiver(), get_ep_params());
         if (!is_loopback()) {
             receiver().connect(&sender(), get_ep_params());
+        }
+
+        if (get_variant_value() == VARIANT_NO_RCACHE) {
+            modify_config("RCACHE_ENABLE", "n");
         }
     }
 

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -18,26 +18,49 @@
 class test_ib_md : public test_md
 {
 protected:
-    void ib_md_umr_check(void *rkey_buffer,
-                         bool amo_access,
-                         size_t size = 8192);
+    void init() override;
+    const uct_ib_md_t &ib_md() const;
+    void ib_md_umr_check(void *rkey_buffer, bool amo_access,
+                         size_t size = 8192, bool aligned = false);
     bool has_ksm() const;
-    bool check_umr(uct_ib_md_t *ib_md) const;
+    bool check_umr() const;
+
+private:
+#ifdef HAVE_MLX5_DV
+    uint32_t m_mlx5_flags = 0;
+#endif
 };
 
+void test_ib_md::init() {
+    test_md::init();
+
+#ifdef HAVE_MLX5_DV
+    /* Save mlx5 IB md flags because failed atomic registration will modify it */
+    if (ib_md().dev.flags & UCT_IB_DEVICE_FLAG_MLX5_PRM) {
+        m_mlx5_flags = ucs_derived_of(md(), uct_ib_mlx5_md_t)->flags;
+    }
+#endif
+}
+
+const uct_ib_md_t &test_ib_md::ib_md() const {
+    return *ucs_derived_of(md(), uct_ib_md_t);
+}
 
 /*
  * Test that ib md does not create umr region if
  * UCT_MD_MEM_ACCESS_REMOTE_ATOMIC is not set
  */
-
-void test_ib_md::ib_md_umr_check(void *rkey_buffer,
-                                 bool amo_access,
-                                 size_t size)
+void test_ib_md::ib_md_umr_check(void *rkey_buffer, bool amo_access,
+                                 size_t size, bool aligned)
 {
     ucs_status_t status;
     size_t alloc_size;
     void *buffer;
+    int ret;
+
+    if (amo_access && (IBV_DEV_ATTR(&ib_md().dev, vendor_part_id) < 4123)) { /* <CX6 */
+        UCS_TEST_SKIP_R("HW does not support atomic indirect MR");
+    }
 
     if (ucs_get_phys_mem_size() < size * 8) {
         UCS_TEST_SKIP_R("not enough physical memory");
@@ -48,8 +71,13 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer,
 
     buffer     = NULL;
     alloc_size = size;
-    status     = ucs_mmap_alloc(&alloc_size, &buffer, 0, "test_umr");
-    ASSERT_UCS_OK(status);
+    if (aligned) {
+        ret = ucs_posix_memalign(&buffer, alloc_size, alloc_size, "test_umr");
+        ASSERT_TRUE(ret == 0);
+    } else {
+        status = ucs_mmap_alloc(&alloc_size, &buffer, 0, "test_umr");
+        ASSERT_UCS_OK(status);
+    }
 
     uct_mem_h memh;
     status = uct_md_mem_reg(md(), buffer, size,
@@ -78,9 +106,7 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer,
     EXPECT_UCS_OK(status);
 
 #ifdef HAVE_MLX5_DV
-    uct_ib_md_t *ib_md = (uct_ib_md_t *)md();
-
-    if ((amo_access && check_umr(ib_md)) || ib_md->relaxed_order) {
+    if ((amo_access && check_umr()) || ib_md().relaxed_order) {
         EXPECT_TRUE(ib_memh->flags & UCT_IB_MEM_FLAG_ATOMIC_MR);
         EXPECT_NE(UCT_IB_INVALID_MKEY, ib_memh->atomic_rkey);
     } else {
@@ -92,27 +118,30 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer,
     status = uct_md_mem_dereg(md(), memh);
     EXPECT_UCS_OK(status);
 
-    ucs_mmap_free(buffer, alloc_size);
+    if (aligned) {
+        ucs_free(buffer);
+    } else {
+        ucs_mmap_free(buffer, alloc_size);
+    }
 }
 
 bool test_ib_md::has_ksm() const {
 #if HAVE_DEVX
-    return (ucs_derived_of(md(), uct_ib_md_t)->dev.flags & UCT_IB_DEVICE_FLAG_MLX5_PRM) &&
-           (ucs_derived_of(md(), uct_ib_mlx5_md_t)->flags & UCT_IB_MLX5_MD_FLAG_KSM);
+    return m_mlx5_flags & UCT_IB_MLX5_MD_FLAG_KSM;
 #elif defined(HAVE_EXP_UMR_KSM)
-    return ucs_derived_of(md(), uct_ib_md_t)->dev.dev_attr.exp_device_cap_flags &
+    return ib_md().dev.dev_attr.exp_device_cap_flags &
            IBV_EXP_DEVICE_UMR_FIXED_SIZE;
 #else
     return false;
 #endif
 }
 
-bool test_ib_md::check_umr(uct_ib_md_t *ib_md) const {
+bool test_ib_md::check_umr() const {
 #if HAVE_DEVX
     return has_ksm();
 #elif HAVE_EXP_UMR
-    if (ib_md->dev.flags & UCT_IB_DEVICE_FLAG_MLX5_PRM) {
-        uct_ib_mlx5_md_t *mlx5_md = ucs_derived_of(ib_md, uct_ib_mlx5_md_t);
+    if (ib_md().dev.flags & UCT_IB_DEVICE_FLAG_MLX5_PRM) {
+        uct_ib_mlx5_md_t *mlx5_md = ucs_derived_of(&ib_md(), uct_ib_mlx5_md_t);
         return mlx5_md->umr_qp != NULL;
     }
     return false;
@@ -164,5 +193,10 @@ UCS_TEST_P(test_ib_md, umr_noninline_klm, "MAX_INLINE_KLM_LIST=1") {
     ib_md_umr_check(&rkey_buffer[0], has_ksm(), UCT_IB_MD_MAX_MR_SIZE + 0x1000);
 }
 #endif
+
+UCS_TEST_P(test_ib_md, aligned) {
+    std::string rkey_buffer(md_attr().rkey_packed_size, '\0');
+    ib_md_umr_check(&rkey_buffer[0], true, UCT_IB_MD_MAX_MR_SIZE, true);
+}
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_ib_md, ib)


### PR DESCRIPTION
## What
fix the approach used to identify ROCm memory type. 

## Why ?
The current algorithm in the code lead to problems with the rocm/ipc component, since memory allocations not capable of providing an ipc handle have been trying to use this component.

## How ?
ROCm memory type is defined as being of type HSA_EXT_POINTER_TYPE_HSA with the owner agent being a GPU.