### PR TITLE
Removing hipMallocManaged test

### DIFF
--- a/test/gtest/ucm/rocm_hooks.cc
+++ b/test/gtest/ucm/rocm_hooks.cc
@@ -120,21 +120,6 @@ UCS_TEST_F(rocm_hooks, test_hipMem_Alloc_Free) {
     check_mem_free_events((void *)dptr, (1 * UCS_MBYTE));
 }
 
-UCS_TEST_F(rocm_hooks, test_hipMallocManaged) {
-    hipError_t ret;
-    void * dptr;
-
-    if (mem_buffer::is_rocm_managed_supported()) {
-        ret = hipMallocManaged(&dptr, 64);
-        ASSERT_EQ(ret, hipSuccess);
-        check_mem_alloc_events((void *)dptr, 64);
-
-        ret = hipFree(dptr);
-        ASSERT_EQ(ret, hipSuccess);
-        check_mem_free_events((void *)dptr, 0, UCS_MEMORY_TYPE_ROCM_MANAGED);
-    }
-}
-
 UCS_TEST_F(rocm_hooks, test_hipMallocPitch) {
     hipError_t ret;
     void * dptr;


### PR DESCRIPTION
## What
removing hipMallocManaged test

## Why ?
hipMallocManaged memory is not device memory and cannot really be used by UCX. The test will not be passing because hsa_amd_memory_pool_allocate is not being used anymore on newer kernels
## How ?
#####
