### PR TITLE
Fixed is_rocm_managed_supported

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -77,20 +77,21 @@ bool mem_buffer::is_rocm_managed_supported()
 {
 #if HAVE_ROCM
     int device_id, has_managed_mem;
+    hipError_t ret;
+    void * dptr;
+    hipPointerAttribute_t attr;
     if ((hipGetDevice(&device_id) == hipSuccess) &&
             (hipDeviceGetAttribute(&has_managed_mem,
                                    hipDeviceAttributeManagedMemory,
                                    device_id) == hipSuccess) &&
             has_managed_mem) {
-        hipError_t ret;
-        void * dptr;
-          hipPointerAttribute_t attr;
         ret = hipMallocManaged(&dptr, 64);
         if (ret == hipSuccess) {
             ret = hipPointerGetAttributes(&attr, dptr);
             if (ret == hipSuccess) {
                 hipFree(dptr);
-                if (attr.memoryType == hipMemoryTypeUnified) return true;
+                if (attr.memoryType == hipMemoryTypeUnified)
+                    return true;
             }
         }
     }

--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -77,11 +77,24 @@ bool mem_buffer::is_rocm_managed_supported()
 {
 #if HAVE_ROCM
     int device_id, has_managed_mem;
-    return ((hipGetDevice(&device_id) == hipSuccess) &&
+    if ((hipGetDevice(&device_id) == hipSuccess) &&
             (hipDeviceGetAttribute(&has_managed_mem,
                                    hipDeviceAttributeManagedMemory,
                                    device_id) == hipSuccess) &&
-            has_managed_mem);
+            has_managed_mem) {
+        hipError_t ret;
+        void * dptr;
+          hipPointerAttribute_t attr;
+        ret = hipMallocManaged(&dptr, 64);
+        if (ret == hipSuccess) {
+            ret = hipPointerGetAttributes(&attr, dptr);
+            if (ret == hipSuccess) {
+                hipFree(dptr);
+                if (attr.memoryType == hipMemoryTypeUnified) return true;
+            }
+        }
+    }
+    return false;
 #else
     return false;
 #endif


### PR DESCRIPTION
## What
hipMallocManaged is not working properly 

## Why ?
hipMallocManaged is using unifed memory and currently cannot be handled by ucx

## How ?

