### PR TITLE
UCT/ROCM: send-to-self fixes

### DIFF
--- a/src/uct/rocm/base/rocm_base.h
+++ b/src/uct/rocm/base/rocm_base.h
@@ -25,9 +25,11 @@ hsa_agent_t uct_rocm_base_get_dev_agent(int dev_num);
 int uct_rocm_base_is_gpu_agent(hsa_agent_t agent);
 int uct_rocm_base_get_gpu_agents(hsa_agent_t **agents);
 int uct_rocm_base_get_dev_num(hsa_agent_t agent);
-hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size,
-                                        void **base_ptr, size_t *base_size,
-                                        hsa_agent_t *agent);
+hsa_status_t uct_rocm_base_get_ptr_info(void *ptr, size_t size, void **base_ptr,
+                                        size_t *base_size,
+                                        hsa_amd_pointer_type_t *hsa_mem_type,
+                                        hsa_agent_t *agent,
+                                        hsa_device_type_t *dev_type);
 ucs_status_t uct_rocm_base_detect_memory_type(uct_md_h md, const void *addr,
                                               size_t length,
                                               ucs_memory_type_t *mem_type_p);

--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -11,6 +11,7 @@
 #include "rocm_copy_ep.h"
 #include "rocm_copy_iface.h"
 #include "rocm_copy_md.h"
+#include "rocm_copy_cache.h"
 
 
 #include <uct/rocm/base/rocm_base.h>
@@ -57,6 +58,35 @@ UCS_CLASS_DEFINE_DELETE_FUNC(uct_rocm_copy_ep_t, uct_ep_t);
      ucs_trace_data(_fmt " to %"PRIx64"(%+ld)", ## __VA_ARGS__, (_remote_addr), \
                     (_rkey))
 
+static void *
+uct_rocm_copy_get_mapped_host_ptr(uct_ep_h tl_ep, void *ptr, size_t size,
+                                  uct_rocm_copy_key_t *rocm_copy_key)
+{
+    uct_rocm_copy_ep_t *ep = ucs_derived_of(tl_ep, uct_rocm_copy_ep_t);
+    size_t offset          = 0;
+    void *mapped_ptr;
+    ucs_status_t status;
+
+    if (rocm_copy_key == NULL ||
+        (((void*)rocm_copy_key->vaddr == rocm_copy_key->dev_ptr) &&
+         ((void*)rocm_copy_key->vaddr != ptr))) {
+        /* key contains rocm address information. Need to lock host address first */
+        status = uct_rocm_copy_cache_map_memhandle(ep->local_memh_cache,
+                                                   (uint64_t)ptr, size,
+                                                   &mapped_ptr);
+        if ((status != UCS_OK) || (mapped_ptr == NULL)) {
+            ucs_trace("Failed to lock memory addr %p", ptr);
+            return NULL;
+        }
+    } else {
+        /* rkey contains host address information */
+        offset     = UCS_PTR_BYTE_DIFF((void*)rocm_copy_key->vaddr, ptr);
+        mapped_ptr = UCS_PTR_BYTE_OFFSET(rocm_copy_key->dev_ptr, offset);
+    }
+
+    return mapped_ptr;
+}
+
 ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep,
                                     uint64_t remote_addr,
                                     const uct_iov_t *iov,
@@ -67,54 +97,118 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep,
     uct_rocm_copy_iface_t *iface       = ucs_derived_of(tl_ep->iface, uct_rocm_copy_iface_t);
     hsa_signal_t signal                = iface->hsa_signal;
     uct_rocm_copy_key_t *rocm_copy_key = (uct_rocm_copy_key_t *) rkey;
-
+    void *remote_addr_mod = NULL, *iov_buffer_mod = NULL;
+    bool remote_addr_is_host = 0, iov_buffer_is_host = 0;
     hsa_status_t status;
-    hsa_agent_t agent;
-    void *src_addr, *dst_addr;
-    void *host_ptr, *dev_ptr, *mapped_ptr;
-    size_t offset;
+    void *src_addr, *dst_addr, *dev_address;
+    hsa_agent_t agent, tmp_agent;
+    hsa_device_type_t dev_type;
+    hsa_amd_pointer_type_t remote_addr_mem_type, iov_buffer_mem_type;
+    size_t dev_size;
 
     ucs_trace("remote addr %p rkey %p size %zu",
               (void*)remote_addr, (void*)rkey, size);
 
-    if (is_put) {   /* Host-to-Device */
-        host_ptr = iov->buffer;
-        dev_ptr  = (void *)remote_addr;
-    } else {        /* Device-to-Host */
-        dev_ptr  = (void *)remote_addr;
-        host_ptr = iov->buffer;
+    /* Analyze remote_addr */
+    status = uct_rocm_base_get_ptr_info((void*)remote_addr, size, &dev_address,
+                                        &dev_size, &remote_addr_mem_type,
+                                        &tmp_agent, &dev_type);
+    if (status != HSA_STATUS_SUCCESS) {
+        ucs_error("failed uct_rocm_base_get_ptr_info for pointer %p",
+                  (void*)remote_addr);
+        return UCS_ERR_IO_ERROR;
     }
 
-    offset     = (uint64_t) host_ptr - rocm_copy_key->vaddr;
-    mapped_ptr = UCS_PTR_BYTE_OFFSET(rocm_copy_key->dev_ptr, offset);
+    if ((remote_addr_mem_type == HSA_EXT_POINTER_TYPE_HSA) &&
+        (dev_type == HSA_DEVICE_TYPE_GPU)) {
+        /* UCS_MEMORY_TYPE_ROCM */
+        remote_addr_mod = (void*)remote_addr;
+        agent           = tmp_agent;
+    } else if ((remote_addr_mem_type == HSA_EXT_POINTER_TYPE_LOCKED) &&
+               (size == dev_size)) {
+        /* locked host memory, e.g. hipHostRegister, OR previously registered */
+        remote_addr_is_host = 1;
+        remote_addr_mod     = dev_address;
+    } else {
+        remote_addr_is_host = 1;
+        remote_addr_mod     = uct_rocm_copy_get_mapped_host_ptr(tl_ep,
+                                                                (void*)remote_addr,
+                                                                size,
+                                                                rocm_copy_key);
+        if (remote_addr_mod == NULL) {
+            ucs_error("failed to map host pointer %p to device address",
+                      (void*)remote_addr);
+            return UCS_ERR_IO_ERROR;
+        }
+    }
 
-    ucs_trace("host_ptr %p offset %zu dev_ptr %p mapped_ptr %p",
-              host_ptr, offset, rocm_copy_key->dev_ptr, mapped_ptr);
-
-    status = uct_rocm_base_get_ptr_info(dev_ptr,  size, NULL, NULL, &agent);
+    /* Analyze iov->buffer */
+    status = uct_rocm_base_get_ptr_info(iov->buffer, size, &dev_address,
+                                        &dev_size, &iov_buffer_mem_type,
+                                        &tmp_agent, &dev_type);
     if (status != HSA_STATUS_SUCCESS) {
-        const char *addr_type = is_put ? "DST" : "SRC";
-        ucs_error("%s addr %p/%lx is not ROCM memory", addr_type, dev_ptr, size);
-        return UCS_ERR_INVALID_ADDR;
+        ucs_error("failed uct_rocm_base_get_ptr_info for pointer %p",
+                  iov->buffer);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    if ((iov_buffer_mem_type == HSA_EXT_POINTER_TYPE_HSA) &&
+        (dev_type == HSA_DEVICE_TYPE_GPU)) {
+        /* UCS_MEMORY_TYPE_ROCM */
+        iov_buffer_mod = iov->buffer;
+        agent          = tmp_agent;
+    } else if ((iov_buffer_mem_type == HSA_EXT_POINTER_TYPE_LOCKED) &&
+               (size == dev_size)) {
+        /* locked host memory (e.g. hipHostRegister) OR previously registered */
+        iov_buffer_is_host = 1;
+        iov_buffer_mod     = dev_address;
+    } else {
+        iov_buffer_is_host = 1;
+        iov_buffer_mod = uct_rocm_copy_get_mapped_host_ptr(tl_ep, iov->buffer,
+                                                           size, NULL);
+        if (iov_buffer_mod == NULL) {
+            ucs_error("failed to map host pointer %p to device address",
+                      iov->buffer);
+            return UCS_ERR_IO_ERROR;
+        }
+    }
+
+    if (iov_buffer_is_host && remote_addr_is_host) {
+        /*
+         * both pointers are host addresses. This can happen in send-to-self scenarios.
+         * Using the original host addresses, not the mapped device addresses.
+         */
+        if (is_put) {
+            src_addr = iov->buffer;
+            dst_addr = (void*)remote_addr;
+        } else {
+            src_addr = (void*)remote_addr;
+            dst_addr = iov->buffer;
+        }
+        ucs_trace("Executing memcpy from %p to %p size %zu\n", src_addr,
+                  dst_addr, size);
+        memcpy(dst_addr, src_addr, size);
+
+        return UCS_OK;
     }
 
     if (is_put) {
-        src_addr = mapped_ptr;
-        dst_addr = dev_ptr;
+        src_addr = iov_buffer_mod;
+        dst_addr = remote_addr_mod;
     } else {
-        src_addr = dev_ptr;
-        dst_addr = mapped_ptr;
+        src_addr = remote_addr_mod;
+        dst_addr = iov_buffer_mod;
     }
 
     hsa_signal_store_screlease(signal, 1);
-    ucs_trace("hsa async copy from src %p to dst %p, len %ld",
-              src_addr, dst_addr, size);
     status = hsa_amd_memory_async_copy(dst_addr, agent,
                                        src_addr, agent,
                                        size, 0, NULL, signal);
 
     while (hsa_signal_wait_scacquire(signal, HSA_SIGNAL_CONDITION_LT, 1,
                                      UINT64_MAX, HSA_WAIT_STATE_ACTIVE));
+    ucs_trace("hsa async copy from src %p to dst %p, len %ld status %d",
+              src_addr, dst_addr, size, (int)status);
     return UCS_OK;
 }
 
@@ -167,10 +261,8 @@ ucs_status_t uct_rocm_copy_ep_put_short(uct_ep_h tl_ep, const void *buffer,
                                         unsigned length, uint64_t remote_addr,
                                         uct_rkey_t rkey)
 {
-    uct_rocm_copy_ep_t *ep       = ucs_derived_of(tl_ep, uct_rocm_copy_ep_t);
     uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rocm_copy_iface_t);
     ucs_status_t status          = UCS_OK;
-    void* base_dev_addr          = NULL;
     uct_iov_t *iov;
 
     if (length <= iface->config.short_h2d_thresh) {
@@ -182,15 +274,7 @@ ucs_status_t uct_rocm_copy_ep_put_short(uct_ep_h tl_ep, const void *buffer,
             return UCS_ERR_NO_MEMORY;
         }
 
-        status = uct_rocm_copy_cache_map_memhandle(ep->local_memh_cache,
-                                                   (uint64_t)buffer,
-                                                   length, &base_dev_addr);
-        if (status != UCS_OK) {
-            ucs_free(iov);
-            return status;
-        }
-
-        iov->buffer = base_dev_addr;
+        iov->buffer = (void*)buffer;
         iov->length = length;
         iov->count  = 1;
         status      = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 1);
@@ -212,10 +296,8 @@ ucs_status_t uct_rocm_copy_ep_get_short(uct_ep_h tl_ep, void *buffer,
                                         unsigned length, uint64_t remote_addr,
                                         uct_rkey_t rkey)
 {
-    uct_rocm_copy_ep_t *ep       = ucs_derived_of(tl_ep, uct_rocm_copy_ep_t);
     uct_rocm_copy_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rocm_copy_iface_t);
     ucs_status_t status          = UCS_OK;
-    void* base_dev_addr          = NULL;
     uct_iov_t *iov;
 
     if (length <= iface->config.short_d2h_thresh) {
@@ -227,15 +309,7 @@ ucs_status_t uct_rocm_copy_ep_get_short(uct_ep_h tl_ep, void *buffer,
             return UCS_ERR_NO_MEMORY;
         }
 
-        status = uct_rocm_copy_cache_map_memhandle(ep->local_memh_cache,
-                                                   (uint64_t)buffer, length,
-                                                   &base_dev_addr);
-        if (status != UCS_OK) {
-            ucs_free(iov);
-            return status;
-        }
-
-        iov->buffer = base_dev_addr;
+        iov->buffer = buffer;
         iov->length = length;
         iov->count  = 1;
         status      = uct_rocm_copy_ep_zcopy(tl_ep, remote_addr, iov, rkey, 0);

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -62,9 +62,12 @@ static hsa_status_t uct_rocm_ipc_pack_key(void *address, size_t length,
     size_t size    = 0;
     hsa_status_t status;
     hsa_agent_t agent;
+    hsa_amd_pointer_type_t mem_type;
 
-    status = uct_rocm_base_get_ptr_info(address, length, &base_ptr, &size, &agent);
-    if ((status != HSA_STATUS_SUCCESS) || (size < length)) {
+    status = uct_rocm_base_get_ptr_info(address, length, &base_ptr, &size,
+                                        &mem_type, &agent, NULL);
+    if ((status != HSA_STATUS_SUCCESS) || (size < length) ||
+        (mem_type == HSA_EXT_POINTER_TYPE_UNKNOWN)) {
         ucs_error("failed to get base ptr for %p/%lx, ROCm returned %p/%lx",
                    address, length, base_ptr, size);
         return status;


### PR DESCRIPTION
1. Cleanup handling of remote_addr vs. iov->buffer in rocm_copy_ep_zcopy.
For put operations, src has to be iov->buffer and dst has to be remote_addr, for get operations exactly the other way around.

2. The rkey does not necessarily contain the registration information of the host buffer, it might be the rkey of the device buffer. Hence, we need to check for that and locally 'lock' the host buffer using hsa_amd_memory_lock() if the provided rkey belongs to a device buffer.

3. Introduce the ability to perform host-to-host memcpy in the component, since the rocm/copy component can be selected for host-to-host operations in send-to-self scenario.

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
