### PR TITLE
ROCM/COPY: add rcache parameters

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -265,7 +265,7 @@ ucs_status_t uct_rocm_copy_ep_put_short(uct_ep_h tl_ep, const void *buffer,
     ucs_status_t status          = UCS_OK;
     uct_iov_t *iov;
 
-    if (length <= iface->config.short_h2d_thresh) {
+    if (length <= iface->config.h2d_thresh) {
         uct_rocm_memcpy_h2d((void*)remote_addr, buffer, length);
     } else {
         iov = ucs_malloc(sizeof(uct_iov_t), "uct_iov_t");
@@ -300,7 +300,7 @@ ucs_status_t uct_rocm_copy_ep_get_short(uct_ep_h tl_ep, void *buffer,
     ucs_status_t status          = UCS_OK;
     uct_iov_t *iov;
 
-    if (length <= iface->config.short_d2h_thresh) {
+    if (length <= iface->config.d2h_thresh) {
         uct_rocm_memcpy_d2h(buffer, (void*)remote_addr, length);
     } else {
         iov = ucs_malloc(sizeof(uct_iov_t), "uct_iov_t");

--- a/src/uct/rocm/copy/rocm_copy_iface.c
+++ b/src/uct/rocm/copy/rocm_copy_iface.c
@@ -31,18 +31,6 @@ static ucs_config_field_t uct_rocm_copy_iface_config_table[] = {
      ucs_offsetof(uct_rocm_copy_iface_config_t, h2d_thresh),
      UCS_CONFIG_TYPE_MEMUNITS},
 
-    {"SHORT_D2H_THRESH", "256",
-     "Threshold for switching to hsa memcpy for device-to-host copies for "
-     "short operations",
-     ucs_offsetof(uct_rocm_copy_iface_config_t, short_d2h_thresh),
-     UCS_CONFIG_TYPE_MEMUNITS},
-
-    {"SHORT_H2D_THRESH", "1m",
-     "Threshold for switching to hsa memcpy for host-to-device copies for "
-     "short operations",
-     ucs_offsetof(uct_rocm_copy_iface_config_t, short_h2d_thresh),
-     UCS_CONFIG_TYPE_MEMUNITS},
-
     {NULL}
 };
 
@@ -220,8 +208,6 @@ static UCS_CLASS_INIT_FUNC(uct_rocm_copy_iface_t, uct_md_h md, uct_worker_h work
     self->id                      = ucs_generate_uuid((uintptr_t)self);
     self->config.d2h_thresh       = config->d2h_thresh;
     self->config.h2d_thresh       = config->h2d_thresh;
-    self->config.short_d2h_thresh = config->short_d2h_thresh;
-    self->config.short_h2d_thresh = config->short_h2d_thresh;
     hsa_signal_create(1, 0, NULL, &self->hsa_signal);
 
     return UCS_OK;

--- a/src/uct/rocm/copy/rocm_copy_iface.h
+++ b/src/uct/rocm/copy/rocm_copy_iface.h
@@ -21,8 +21,6 @@ typedef struct uct_rocm_copy_iface {
     struct {
         size_t                  d2h_thresh;
         size_t                  h2d_thresh;
-        size_t                  short_d2h_thresh;
-        size_t                  short_h2d_thresh;
     } config;
 } uct_rocm_copy_iface_t;
 

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -22,17 +22,18 @@
 #include <uct/api/v2/uct_v2.h>
 #include <hsa_ext_amd.h>
 
-static ucs_config_field_t uct_rocm_copy_md_config_table[] = {
-    {"", "", NULL,
-     ucs_offsetof(uct_rocm_copy_md_config_t, super),
-     UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
+static ucs_config_field_t uct_rocm_copy_md_config_table[] =
+        {{"", "", NULL, ucs_offsetof(uct_rocm_copy_md_config_t, super),
+          UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
 
-    {"RCACHE", "try", "Enable using memory registration cache",
-     ucs_offsetof(uct_rocm_copy_md_config_t, enable_rcache),
-     UCS_CONFIG_TYPE_TERNARY},
+         {"RCACHE", "try", "Enable using memory registration cache",
+          ucs_offsetof(uct_rocm_copy_md_config_t, enable_rcache),
+          UCS_CONFIG_TYPE_TERNARY},
 
-    {NULL}
-};
+         {"", "", NULL, ucs_offsetof(uct_rocm_copy_md_config_t, rcache),
+          UCS_CONFIG_TYPE_TABLE(uct_md_config_rcache_table)},
+
+         {NULL}};
 
 static ucs_status_t
 uct_rocm_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
@@ -401,6 +402,7 @@ uct_rocm_copy_md_open(uct_component_h component, const char *md_name,
     md->reg_cost        = UCS_LINEAR_FUNC_ZERO;
 
     if (md_config->enable_rcache != UCS_NO) {
+        uct_md_set_rcache_params(&rcache_params, &md_config->rcache);
         rcache_params.region_struct_size = sizeof(uct_rocm_copy_rcache_region_t);
         rcache_params.alignment          = ucs_get_page_size();
         rcache_params.max_alignment      = ucs_get_page_size();


### PR DESCRIPTION

## What
1. add parameters to allow control over the rcache used by the rocm_copy component.
2. Remove the short d2h and h2d parameters, there is no need for separate threshold parameters for short vs. zcopy functions.

## Why ?
Improve user experience and control of the available options.

