### PR TITLE
UCT/ROCM: include sys/arch/cpu.h

### DIFF
--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -16,6 +16,7 @@
 #include <ucs/debug/log.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/math.h>
+#include <ucs/arch/cpu.h>
 #include <ucs/debug/memtrack_int.h>
 #include <ucm/api/ucm.h>
 #include <ucs/type/class.h>


### PR DESCRIPTION
## What
include sys/arch/cpu.h to avoid a problem initializing the rocm_copy md domain due to UCS_SYS_CACHE_LINE_SIZE being unset.
