### PR TITLE
(v1.14.x) GTEST/COMMON: Add HIP_VERSION condition for ROCm compatibility

### DIFF
--- a/test/gtest/common/mem_buffer.cc
+++ b/test/gtest/common/mem_buffer.cc
@@ -33,7 +33,8 @@
 #endif
 
 #if HAVE_ROCM
-#  include <hip_runtime.h>
+#include <hip_runtime.h>
+#include <hip_version.h>
 
 #define ROCM_CALL(_code) \
     do { \
@@ -91,7 +92,13 @@ bool mem_buffer::is_rocm_managed_supported()
     }
 
     hipFree(dptr);
+
+#if HIP_VERSION >= 50500000
+    return attr.type == hipMemoryTypeUnified;
+#else
     return attr.memoryType == hipMemoryTypeUnified;
+#endif
+
 #else
     return false;
 #endif


### PR DESCRIPTION
## What
Adds condition based on HIP_VERSION for using `type` instead of `memoryType` in `hipPointerAttribute_t`.

## Why ?
From ROCm 5.5 onwards, `memoryType` is deprecated and `type` is used instead in `hipPointerAttribute_t`.